### PR TITLE
Hurry over OWNERS_ALIASES name change from community #785 / #797

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,8 +4,8 @@ approvers:
 - technical-oversight-committee
 - knative-release-leads
 - networking-wg-leads
-- net-ingressv2-approvers
+- net-gateway-api-approvers
 
 reviewers:
 - networking-wg-leads
-- net-ingressv2-approvers
+- net-gateway-api-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -19,6 +19,10 @@ aliases:
   - dsimansk
   - navidshaikh
   - rhuss
+  container-freezer-approvers:
+  - julz
+  - markusthoemmes
+  - psschwei
   control-protocol-approvers:
   - devguyio
   - eric-sap
@@ -142,7 +146,7 @@ aliases:
   - nicolaferraro
   - rhuss
   knative-admin:
-  - ZhiminXiang
+  - bmo
   - bsnchan
   - dprotaso
   - evankanderson
@@ -157,9 +161,31 @@ aliases:
   - rhuss
   - thisisnotapril
   - vaikas
-  knative-release-leads:
+  knative-milestone-maintainers:
   - ZhiminXiang
+  - akashrv
+  - aslom
+  - chaodaiG
+  - csantanapr
+  - dprotaso
   - evankanderson
+  - josephburnett
+  - julz
+  - k4leung4
+  - lionelvillard
+  - markusthoemmes
+  - matzew
+  - mikehelmick
+  - n3wscott
+  - nak3
+  - navidshaikh
+  - rhuss
+  - tcnghia
+  - vagababov
+  - vaikas
+  knative-release-leads:
+  - bmo
+  - julz
   knative-robots:
   - knative-prow-releaser-robot
   - knative-prow-robot
@@ -174,11 +200,11 @@ aliases:
   net-contour-approvers:
   - dprotaso
   - tcnghia
-  net-http01-approvers:
-  - tcnghia
-  net-ingressv2-approvers:
+  net-gateway-api-approvers:
   - markusthoemmes
   - nak3
+  - tcnghia
+  net-http01-approvers:
   - tcnghia
   net-istio-approvers:
   - JRBANCEL


### PR DESCRIPTION
This is a copy of the file in #785; I wanted to copy this over after the rename by hand because it needs a corresponding OWNERS file update, and this was easier than doing a two-teams-with-same-members dance.
