### PR TITLE
Replace net-ingressv2 with net-gateway-api

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -10,7 +10,7 @@ on:
 defaults:
   run:
     shell: bash
-    working-directory: ./src/knative.dev/net-ingressv2
+    working-directory: ./src/knative.dev/net-gateway-api
 
 jobs:
   e2e-tests:
@@ -72,7 +72,7 @@ jobs:
     - name: Check out code onto GOPATH
       uses: actions/checkout@v2
       with:
-        path: ./src/knative.dev/net-ingressv2
+        path: ./src/knative.dev/net-gateway-api
 
     - name: Install KinD
       run: |
@@ -201,7 +201,7 @@ jobs:
         SLACK_USERNAME: github-actions
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-        SLACK_CHANNEL: 'net-ingressv2'
+        SLACK_CHANNEL: 'net-gateway-api'
         SLACK_COLOR: '#8E1600'
         MSG_MINIMAL: 'true'
         SLACK_TITLE: Periodic ${{ matrix.k8s-version }} failed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contribution guidelines
 
-So you want to hack on Knative `net-ingressv2`? Yay! Please refer to Knative's
+So you want to hack on Knative `net-gateway-api`? Yay! Please refer to Knative's
 overall [contribution guidelines](https://www.knative.dev/contributing/) to find
 out how you can help.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 This doc explains how to setup a development environment so you can get started
 [contributing](https://www.knative.dev/contributing/) to Knative
-`net-ingressv2`. Also take a look at:
+`net-gateway-api`. Also take a look at:
 
 - [The pull request workflow](https://knative.dev/community/contributing/reviewing/)
 
@@ -21,7 +21,7 @@ Before submitting a PR, see also [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 You must install these tools:
 
-1. [`go`](https://golang.org/doc/install): The language Knative `net-ingressv2`
+1. [`go`](https://golang.org/doc/install): The language Knative `net-gateway-api`
    is built in
 1. [`git`](https://help.github.com/articles/set-up-git/): For source control
 1. [`dep`](https://github.com/golang/dep): For managing external dependencies.
@@ -47,7 +47,7 @@ export PATH="${PATH}:${GOPATH}/bin"
 ### Checkout your fork
 
 The Go tools require that you clone the repository to the
-`src/knative.dev/net-ingressv2` directory in your
+`src/knative.dev/net-gateway-api` directory in your
 [`GOPATH`](https://github.com/golang/go/wiki/SettingGOPATH).
 
 To check out this repository:
@@ -60,9 +60,9 @@ To check out this repository:
 ```shell
 mkdir -p ${GOPATH}/src/knative.dev
 cd ${GOPATH}/src/knative.dev
-git clone git@github.com:${YOUR_GITHUB_USERNAME}/net-ingressv2.git
-cd net-ingressv2
-git remote add upstream https://github.com/knative-sandbox/net-ingressv2.git
+git clone git@github.com:${YOUR_GITHUB_USERNAME}/net-gateway-api.git
+cd net-gateway-api
+git remote add upstream https://github.com/knative-sandbox/net-gateway-api.git
 git remote set-url --push upstream no_push
 ```
 
@@ -118,7 +118,7 @@ go test -v -tags=e2e -count=1  ./test/conformance/ingressv2/  -run "TestIngressC
 ```
 
 Some tests are still not available. Please see
-https://github.com/knative-sandbox/net-ingressv2/issues/23.
+https://github.com/knative-sandbox/net-gateway-api/issues/23.
 
 ### Test with Contoour
 
@@ -167,4 +167,4 @@ go test -v -tags=e2e -count=1  ./test/conformance/ingressv2/  -run "TestIngressC
 ```
 
 Some tests are still not available. Please see
-https://github.com/knative-sandbox/net-ingressv2/issues/36.
+https://github.com/knative-sandbox/net-gateway-api/issues/36.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Knative net-gateway-api
 
 [![GoDoc](https://godoc.org/knative.dev/net-gateway-api?status.svg)](https://godoc.org/knative.dev/net-gateway-api)
-[![Go Report Card](https://goreportcard.com/badge/knative/net-gateway-api)](https://goreportcard.com/report/knative/net-ingressv2)
+[![Go Report Card](https://goreportcard.com/badge/knative/net-gateway-api)](https://goreportcard.com/report/knative/net-gateway-api)
 
 This repository contains a KIngress implementation and testing for Knative
 integration with the 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/knative/net-gateway-api)](https://goreportcard.com/report/knative/net-gateway-api)
 
 This repository contains a KIngress implementation and testing for Knative
-integration with the 
+integration with the
 [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/).
 The tests are same with
 [Knative networking](https://github.com/knative/networking/tree/main/test/conformance)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module knative.dev/net-ingressv2
+module knative.dev/net-gateway-api
 
 go 1.16
 

--- a/test/conformance/ingressv2/basic.go
+++ b/test/conformance/ingressv2/basic.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"knative.dev/net-ingressv2/test"
+	"knative.dev/net-gateway-api/test"
 	"knative.dev/networking/pkg/apis/networking"
 	gwv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )

--- a/test/conformance/ingressv2/grpc.go
+++ b/test/conformance/ingressv2/grpc.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
-	"knative.dev/net-ingressv2/test"
+	"knative.dev/net-gateway-api/test"
 	ping "knative.dev/networking/test/test_images/grpc-ping/proto"
 	gwv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
@@ -56,7 +56,7 @@ func TestGRPC(t *testing.T) {
 			}},
 		}}})
 
-	// TODO: https://github.com/knative-sandbox/net-ingressv2/issues/18
+	// TODO: https://github.com/knative-sandbox/net-gateway-api/issues/18
 	// As Ingress v2 does not have prober, it needs to make sure backend is ready.
 	client := &http.Client{Transport: &uaRoundTripper{RoundTripper: &http.Transport{DialContext: dialCtx}}}
 	waitForBackend(t, client, "http://"+name+".example.com")
@@ -121,7 +121,7 @@ func TestGRPCSplit(t *testing.T) {
 			},
 		}}})
 
-	// TODO: https://github.com/knative-sandbox/net-ingressv2/issues/18
+	// TODO: https://github.com/knative-sandbox/net-gateway-api/issues/18
 	// As Ingress v2 does not have prober, it needs to make sure backend is ready.
 	client := &http.Client{Transport: &uaRoundTripper{RoundTripper: &http.Transport{DialContext: dialCtx}}}
 	waitForBackend(t, client, "http://"+name+".example.com")

--- a/test/conformance/ingressv2/headers.go
+++ b/test/conformance/ingressv2/headers.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
-	"knative.dev/net-ingressv2/test"
+	"knative.dev/net-gateway-api/test"
 	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/ptr"

--- a/test/conformance/ingressv2/hosts.go
+++ b/test/conformance/ingressv2/hosts.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"knative.dev/net-ingressv2/test"
+	"knative.dev/net-gateway-api/test"
 	"knative.dev/networking/pkg/apis/networking"
 	gwv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )

--- a/test/conformance/ingressv2/path.go
+++ b/test/conformance/ingressv2/path.go
@@ -24,7 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
-	"knative.dev/net-ingressv2/test"
+	"knative.dev/net-gateway-api/test"
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/pool"
 	gwv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"

--- a/test/conformance/ingressv2/percentage.go
+++ b/test/conformance/ingressv2/percentage.go
@@ -22,7 +22,7 @@ import (
 	"math"
 	"testing"
 
-	"knative.dev/net-ingressv2/test"
+	"knative.dev/net-gateway-api/test"
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/pool"
 	gwv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"

--- a/test/conformance/ingressv2/rewrite.go
+++ b/test/conformance/ingressv2/rewrite.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"knative.dev/net-ingressv2/test"
+	"knative.dev/net-gateway-api/test"
 	"knative.dev/networking/pkg/apis/networking"
 	gwv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )

--- a/test/conformance/ingressv2/rule.go
+++ b/test/conformance/ingressv2/rule.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/utils/pointer"
-	"knative.dev/net-ingressv2/test"
+	"knative.dev/net-gateway-api/test"
 	"knative.dev/networking/pkg/apis/networking"
 	gwv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )

--- a/test/conformance/ingressv2/timeout.go
+++ b/test/conformance/ingressv2/timeout.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"knative.dev/net-ingressv2/test"
+	"knative.dev/net-gateway-api/test"
 	gwv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
@@ -66,7 +66,7 @@ func TestTimeout(t *testing.T) {
 		delay: timeout,
 	}}
 
-	// TODO: https://github.com/knative-sandbox/net-ingressv2/issues/18
+	// TODO: https://github.com/knative-sandbox/net-gateway-api/issues/18
 	// As Ingress v2 does not have prober, it needs to make sure backend is ready.
 	waitForBackend(t, client, "http://"+name+".example.com?initialTimeout=0&timeout=0")
 

--- a/test/conformance/ingressv2/util.go
+++ b/test/conformance/ingressv2/util.go
@@ -48,7 +48,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"knative.dev/net-ingressv2/test"
+	"knative.dev/net-gateway-api/test"
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/test/types"
 	"knative.dev/pkg/network"
@@ -95,10 +95,10 @@ var testLocalGateway = &gatewayv1alpha1.RouteGateways{
 }
 
 // gatewayLabel is added to HTTPRoute. The external gateway selects the generated HTTPRoute by this label.
-var gatewayLabel = map[string]string{"knative-e2e-test": "net-ingressv2"}
+var gatewayLabel = map[string]string{"knative-e2e-test": "net-gateway-api"}
 
 // gatewayLabel is added to HTTPRoute. The local gateway selects the generated HTTPRoute by this label.
-var gatewayLocalLabel = map[string]string{"knative-e2e-test": "net-ingressv2-local"}
+var gatewayLocalLabel = map[string]string{"knative-e2e-test": "net-gateway-api-local"}
 
 // uaRoundTripper wraps the given http.RoundTripper and
 // sets a custom UserAgent.

--- a/test/conformance/ingressv2/visibility.go
+++ b/test/conformance/ingressv2/visibility.go
@@ -26,7 +26,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
-	"knative.dev/net-ingressv2/test"
+	"knative.dev/net-gateway-api/test"
 	"knative.dev/networking/pkg/apis/networking"
 	nettest "knative.dev/networking/test"
 	"knative.dev/pkg/pool"

--- a/test/conformance/ingressv2/websocket.go
+++ b/test/conformance/ingressv2/websocket.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gorilla/websocket"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
-	"knative.dev/net-ingressv2/test"
+	"knative.dev/net-gateway-api/test"
 	gwv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -30,7 +30,7 @@ function upload_test_images() {
 
     for yaml in $(find ${image_dir} -name '*.yaml'); do
       # Rewrite image reference to use vendor.
-      sed "s@knative.dev/networking@knative.dev/net-ingressv2/vendor/knative.dev/networking@g" $yaml \
+      sed "s@knative.dev/networking@knative.dev/net-gateway-api/vendor/knative.dev/networking@g" $yaml \
         `# ko resolve is being used for the side-effect of publishing images,` \
         `# so the resulting yaml produced is ignored.` \
         | ko resolve ${tag_option} -RBf- > /dev/null

--- a/third_party/contour-head/gateway/gateway-external.yaml
+++ b/third_party/contour-head/gateway/gateway-external.yaml
@@ -60,7 +60,7 @@ spec:
       kind: HTTPRoute
       selector:
         matchLabels:
-          knative-e2e-test: "net-ingressv2"
+          knative-e2e-test: "net-gateway-api"
       namespaces:
         from: "All"
   - protocol: HTTPS
@@ -73,6 +73,6 @@ spec:
       kind: HTTPRoute
       selector:
         matchLabels:
-          knative-e2e-test: "net-ingressv2"
+          knative-e2e-test: "net-gateway-api"
       namespaces:
         from: "All"

--- a/third_party/contour-head/gateway/gateway-internal.yaml
+++ b/third_party/contour-head/gateway/gateway-internal.yaml
@@ -60,7 +60,7 @@ spec:
       kind: HTTPRoute
       selector:
         matchLabels:
-          knative-e2e-test: "net-ingressv2-local"
+          knative-e2e-test: "net-gateway-api-local"
       namespaces:
         from: "All"
   - protocol: HTTPS
@@ -73,6 +73,6 @@ spec:
       kind: HTTPRoute
       selector:
         matchLabels:
-          knative-e2e-test: "net-ingressv2-local"
+          knative-e2e-test: "net-gateway-api-local"
       namespaces:
         from: "All"

--- a/third_party/istio-head/gateway/300-gateway-local.yaml
+++ b/third_party/istio-head/gateway/300-gateway-local.yaml
@@ -29,6 +29,6 @@ spec:
       kind: HTTPRoute
       selector:
         matchLabels:
-          knative-e2e-test: "net-ingressv2-local"
+          knative-e2e-test: "net-gateway-api-local"
       namespaces:
         from: "All"

--- a/third_party/istio-head/gateway/300-gateway.yaml
+++ b/third_party/istio-head/gateway/300-gateway.yaml
@@ -29,7 +29,7 @@ spec:
       kind: HTTPRoute
       selector:
         matchLabels:
-          knative-e2e-test: "net-ingressv2"
+          knative-e2e-test: "net-gateway-api"
       namespaces:
         from: "All"
   - protocol: HTTPS
@@ -42,6 +42,6 @@ spec:
       kind: HTTPRoute
       selector:
         matchLabels:
-          knative-e2e-test: "net-ingressv2"
+          knative-e2e-test: "net-gateway-api"
       namespaces:
         from: "All"


### PR DESCRIPTION
As repo name was updated, this patch replaces all `net-ingressv2` with `net-gateway-api`.