### PR TITLE
Pin Contour version to v1.19.0

### DIFF
--- a/third_party/contour-head/install-operator.sh
+++ b/third_party/contour-head/install-operator.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CONTOUR_OPERATOR_VERSION="main" # This is for controlling which version of contour-operator we want to use.
+CONTOUR_OPERATOR_VERSION="v1.19.0" # This is for controlling which version of contour-operator we want to use.
 YAML_URL="https://raw.githubusercontent.com/projectcontour/contour-operator/${CONTOUR_OPERATOR_VERSION}/examples/operator/operator.yaml"
 
 kubectl apply -f $YAML_URL


### PR DESCRIPTION
Since Contour main branch started Gateway API v1alpha2 as
https://github.com/projectcontour/contour-operator/pull/456, this patch changes to pin Contour
version to v1.19.0 which supports Gateway v1alpha1.
