### PR TITLE
Fix to parse `NamespacedName` in config-gateway

### DIFF
--- a/pkg/reconciler/ingress/config/gateway_test.go
+++ b/pkg/reconciler/ingress/config/gateway_test.go
@@ -23,16 +23,13 @@ import (
 )
 
 func TestGateway(t *testing.T) {
-	cm, _ := ConfigMapsFromTestFile(t, GatewayConfigName)
+	cm, example := ConfigMapsFromTestFile(t, GatewayConfigName)
 
 	if _, err := NewGatewayFromConfigMap(cm); err != nil {
 		t.Error("NewContourFromConfigMap(actual) =", err)
 	}
 
-	// TODO: https://github.com/knative-sandbox/net-gateway-api/issues/171
-	/*
-		if _, err := NewGatewayFromConfigMap(example); err != nil {
-			t.Error("NewContourFromConfigMap(example) =", err)
-		}
-	*/
+	if _, err := NewGatewayFromConfigMap(example); err != nil {
+		t.Error("NewContourFromConfigMap(example) =", err)
+	}
 }


### PR DESCRIPTION
Currently configmap fails to `yaml.Unmarshal` due to non-string value.
So this patch uses `visibilityValue` struct to parse the config-gateway.

Fix https://github.com/knative-sandbox/net-gateway-api/issues/171
