### PR TITLE
Use each IP to probe public and private services

### DIFF
--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -94,10 +94,13 @@ var (
 		Network: &network.Config{},
 		Gateway: &config.Gateway{
 			Gateways: map[v1alpha1.IngressVisibility]config.GatewayConfig{
-				v1alpha1.IngressVisibilityExternalIP: {},
+				v1alpha1.IngressVisibilityExternalIP: {
+					Service: &types.NamespacedName{Namespace: "istio-system", Name: "istio-gateway"},
+				},
 				v1alpha1.IngressVisibilityClusterLocal: {
 					Service: &types.NamespacedName{Namespace: "istio-system", Name: "knative-local-gateway"},
-				}},
+				},
+			},
 		},
 	}
 )

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -53,16 +53,16 @@ type gatewayPodTargetLister struct {
 
 func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1alpha1.Ingress) ([]status.ProbeTarget, error) {
 	var err error
-	visibilityToEndpointIPs := map[v1alpha1.IngressVisibility]sets.String{}
+	var privateIPs, publicIPs sets.String
 
-	if visibilityToEndpointIPs[v1alpha1.IngressVisibilityClusterLocal], err = l.endpointIPs(ctx, v1alpha1.IngressVisibilityClusterLocal); err != nil {
+	if privateIPs, err = l.endpointIPs(ctx, v1alpha1.IngressVisibilityClusterLocal); err != nil {
 		return nil, err
 	}
-	if visibilityToEndpointIPs[v1alpha1.IngressVisibilityExternalIP], err = l.endpointIPs(ctx, v1alpha1.IngressVisibilityExternalIP); err != nil {
+	if publicIPs, err = l.endpointIPs(ctx, v1alpha1.IngressVisibilityExternalIP); err != nil {
 		return nil, err
 	}
 
-	return l.getIngressUrls(ing, visibilityToEndpointIPs)
+	return l.getIngressUrls(ing, privateIPs, publicIPs)
 }
 
 func (l *gatewayPodTargetLister) endpointIPs(ctx context.Context, visibility v1alpha1.IngressVisibility) (sets.String, error) {
@@ -86,7 +86,7 @@ func (l *gatewayPodTargetLister) endpointIPs(ctx context.Context, visibility v1a
 	return readyIPs, nil
 }
 
-func (l *gatewayPodTargetLister) getIngressUrls(ing *v1alpha1.Ingress, ips map[v1alpha1.IngressVisibility]sets.String) ([]status.ProbeTarget, error) {
+func (l *gatewayPodTargetLister) getIngressUrls(ing *v1alpha1.Ingress, privateIPs, publicIPs sets.String) ([]status.ProbeTarget, error) {
 
 	targets := make([]status.ProbeTarget, 0, len(ing.Spec.Rules))
 	for _, rule := range ing.Spec.Rules {
@@ -97,7 +97,7 @@ func (l *gatewayPodTargetLister) getIngressUrls(ing *v1alpha1.Ingress, ips map[v
 
 		if rule.Visibility == v1alpha1.IngressVisibilityExternalIP {
 			target = status.ProbeTarget{
-				PodIPs: ips[rule.Visibility],
+				PodIPs: publicIPs,
 			}
 			if ing.Spec.HTTPOption == v1alpha1.HTTPOptionRedirected {
 				target.PodPort = HTTPSPortExternal
@@ -108,7 +108,7 @@ func (l *gatewayPodTargetLister) getIngressUrls(ing *v1alpha1.Ingress, ips map[v
 			}
 		} else {
 			target = status.ProbeTarget{
-				PodIPs:  ips[rule.Visibility],
+				PodIPs:  privateIPs,
 				PodPort: HTTPPortInternal,
 				URLs:    domainsToURL(domains, scheme),
 			}

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -52,13 +52,12 @@ type gatewayPodTargetLister struct {
 }
 
 func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1alpha1.Ingress) ([]status.ProbeTarget, error) {
-	var err error
-	var privateIPs, publicIPs sets.String
-
-	if privateIPs, err = l.endpointIPs(ctx, v1alpha1.IngressVisibilityClusterLocal); err != nil {
+	privateIPs, err := l.endpointIPs(ctx, v1alpha1.IngressVisibilityClusterLocal)
+	if err != nil {
 		return nil, err
 	}
-	if publicIPs, err = l.endpointIPs(ctx, v1alpha1.IngressVisibilityExternalIP); err != nil {
+	publicIPs, err := l.endpointIPs(ctx, v1alpha1.IngressVisibilityExternalIP)
+	if err != nil {
 		return nil, err
 	}
 

--- a/third_party/contour-head/gateway/gateway-internal.yaml
+++ b/third_party/contour-head/gateway/gateway-internal.yaml
@@ -70,6 +70,10 @@ spec:
         from: "All"
   - protocol: HTTPS
     port: 443
+    tls:
+      mode: Terminate
+      routeOverride:
+        certificate: Allow
     routes:
       kind: HTTPRoute
       selector:

--- a/third_party/contour-head/gateway/gateway-internal.yaml
+++ b/third_party/contour-head/gateway/gateway-internal.yaml
@@ -31,6 +31,11 @@ spec:
   ingressClassName: contour-internal
   networkPublishing:
     envoy:
+      containerPorts:
+      - name: http
+        portNumber: 8081
+      - name: https
+        portNumber: 8443
       type: ClusterIPService
 ---
 kind: GatewayClass
@@ -65,10 +70,6 @@ spec:
         from: "All"
   - protocol: HTTPS
     port: 443
-    tls:
-      mode: Terminate
-      routeOverride:
-        certificate: Allow
     routes:
       kind: HTTPRoute
       selector:


### PR DESCRIPTION
Currently prober code probes public (`hello.example.com`) and private (`hello.default.svc.cluster.local`) services by ingress's private endpoint IP only. 

i.e.
- `-H "hello.example.com"` `<private ingress's IP>`
- `-H "hello.default.svc.cluster.local"` `<private ingress's IP>`

This probe code works with Istio and Kourier as they map two services (local and external) to one deployment.
However, it does not work with Contour as it maps one service to one deployment.

So, this patch fixes the prober code to use each public and private IPs for external and local service.

i.e.
- `-H "hello.example.com"` `<public inigress's IP>`
- `-H "hello.default.svc.cluster.local"` `<private inigress's IP>`

Part of https://github.com/knative-sandbox/net-gateway-api/pull/179
