### PR TITLE
Drop t.Parallel() in TestVisibilitySplit until issues/185 was fixed

### DIFF
--- a/test/conformance/ingressv2/visibility.go
+++ b/test/conformance/ingressv2/visibility.go
@@ -99,7 +99,8 @@ func testProxyToHelloworld(ctx context.Context, t *testing.T, clients *test.Clie
 }
 
 func TestVisibilitySplit(t *testing.T) {
-	t.Parallel()
+	// TODO: https://github.com/knative-sandbox/net-gateway-api/issues/185
+	// t.Parallel()
 	ctx, clients := context.Background(), test.Setup(t)
 
 	// Use a post-split injected header to establish which split we are sending traffic to.

--- a/test/kind-conformance-contour.sh
+++ b/test/kind-conformance-contour.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 
 IPS=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )
 CLUSTER_SUFFIX=${CLUSTER_SUFFIX:-cluster.local}
-UNSUPPORTED_TESTS="basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility/split,headers/tags,host-rewrite,visibility/split"
+UNSUPPORTED_TESTS="basics/http2,websocket,websocket/split,grpc,grpc/split,host-rewrite"
 
 export GATEWAY_OVERRIDE=envoy
 export GATEWAY_NAMESPACE_OVERRIDE=contour-external
@@ -40,7 +40,6 @@ ko resolve -f ./third_party/contour-head/gateway/ | \
 
 echo ">> Running conformance tests"
 go test -race -count=1 -short -timeout=20m -tags=e2e ./test/conformance/ingressv2 \
-   --ingressClass=contour \
    --enable-alpha --enable-beta \
    --skip-tests="${UNSUPPORTED_TESTS}" \
    --ingressendpoint="${IPS[0]}" \

--- a/test/kind-conformance-istio.sh
+++ b/test/kind-conformance-istio.sh
@@ -34,7 +34,6 @@ kubectl apply -f ./third_party/istio-head/gateway/
 
 echo ">> Running conformance tests"
 go test -race -count=1 -short -timeout=20m -tags=e2e ./test/conformance/ingressv2 \
-   --ingressClass=istio \
    --enable-alpha --enable-beta \
    --skip-tests="${UNSUPPORTED_TESTS}" \
    --ingressendpoint="${IPS[0]}" \


### PR DESCRIPTION
Currently `TestVisibilitySplit` is flaky so drop `t.Parallel()` until
issues/185 was solved.

This patch also remove some unsupported test from contour.
