### PR TITLE
Add hack/release.sh

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -18,17 +18,20 @@ metadata:
   name: net-gateway-api-controller
   namespace: knative-serving
   labels:
-    samples.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: net-gateway-api
+    app.kubernetes.io/component: net-gateway-api
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-serving
+    serving.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: controller
+      app: net-gateway-api-controller
   template:
     metadata:
       labels:
-        app: controller
-        samples.knative.dev/release: devel
+        app: net-gateway-api-controller
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -57,6 +60,8 @@ spec:
         ports:
         - name: metrics
           containerPort: 9090
+        - name: profiling
+          containerPort: 8008
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -67,7 +72,7 @@ spec:
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
         - name: METRICS_DOMAIN
-          value: knative.dev/samples
+          value: knative.dev/net-gateway-api
 
         securityContext:
           allowPrivilegeEscalation: false

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Documentation about this script and how to use it can be found
+# at https://github.com/knative/hack
+
+source $(dirname $0)/../vendor/knative.dev/hack/release.sh
+
+# Yaml files to generate, and the source config dir for them.
+declare -A COMPONENTS
+COMPONENTS=(
+  ["net-gateway-api.yaml"]="config"
+)
+readonly COMPONENTS
+
+declare -A RELEASES
+RELEASES=(
+  ["release.yaml"]="net-gateway-api.yaml"
+)
+readonly RELEASES
+
+function build_release() {
+  # Update release labels if this is a tagged release
+  if [[ -n "${TAG}" ]]; then
+    echo "Tagged release, updating release labels to serving.knative.dev/release: \"${TAG}\" and app.kubernetes.io/version: \"${TAG}\""
+    LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|" -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
+  else
+    echo "Untagged release, will NOT update release labels"
+    LABEL_YAML_CMD=(cat)
+  fi
+
+  # Build the components
+  local all_yamls=()
+  for yaml in "${!COMPONENTS[@]}"; do
+    local config="${COMPONENTS[${yaml}]}"
+    echo "Building Knative net-gateway-api - ${config}"
+    ko resolve ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
+    all_yamls+=(${yaml})
+  done
+  # Assemble the release
+  for yaml in "${!RELEASES[@]}"; do
+    echo "Assembling Knative net-gateway-api - ${yaml}"
+    echo "" > ${yaml}
+    for component in ${RELEASES[${yaml}]}; do
+      echo "---" >> ${yaml}
+      echo "# ${component}" >> ${yaml}
+      cat ${component} >> ${yaml}
+    done
+    all_yamls+=(${yaml})
+  done
+  ARTIFACTS_TO_PUBLISH="${all_yamls[@]}"
+}
+
+main $@


### PR DESCRIPTION
This patch adds `hack/release.sh` with clean up of `controller.yaml`.