### PR TITLE
Add HA test for net-gateway-api controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,6 @@
 [![GoDoc](https://godoc.org/knative-sandbox.dev/net-gateway-api?status.svg)](https://godoc.org/knative.dev/net-gateway-api)
 [![Go Report Card](https://goreportcard.com/badge/knative-sandbox/net-gateway-api)](https://goreportcard.com/report/knative-sandbox/net-gateway-api)
 
-**[This component is ALPHA](https://github.com/knative/community/tree/main/mechanics/MATURITY-LEVELS.md)**
-
-[![GoDoc](https://godoc.org/knative-sandbox.dev/net-gateway-api?status.svg)](https://godoc.org/knative.dev/net-gateway-api)
-[![Go Report Card](https://goreportcard.com/badge/knative-sandbox/net-gateway-api)](https://goreportcard.com/report/knative-sandbox/net-gateway-api)
-
 net-gateway-api repository contains a KIngress implementation and testing for Knative
 integration with the
 [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/).
@@ -74,7 +69,7 @@ EOF
 ```
 
 - (OPTIONAL) For testing purposes, you can use port-forwarding to make requests
-  to Kourier from your machine:
+  to ingress from your machine:
 
 ```bash
 kubectl port-forward  -n istio-system $(kubectl get pod -n istio-system -l "app=istio-ingressgateway" --output=jsonpath="{.items[0].metadata.name}") 8080:8080

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -35,6 +35,12 @@ go_test_e2e -timeout=20m -tags=e2e -parallel=12 \
   --skip-tests="${UNSUPPORTED_TESTS}" \
   --ingressClass=gateway-api.ingress.networking.knative.dev || failed=1
 
+# Give the controller time to sync with the rest of the system components.
+sleep 30
+
+go_test_e2e -timeout=15m -failfast -parallel=1 ./test/ha -spoofinterval="10ms" \
+  --ingressClass=gateway-api.ingress.networking.knative.dev || failed=1
+
 (( failed )) && dump_cluster_state
 (( failed )) && fail_test
 

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -1,0 +1,93 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ha
+
+import (
+	"context"
+	"testing"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/networking/pkg/apis/networking"
+	"knative.dev/networking/test"
+	"knative.dev/networking/test/conformance/ingress"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/ptr"
+	pkgTest "knative.dev/pkg/test"
+	pkgHa "knative.dev/pkg/test/ha"
+)
+
+const (
+	controlNamespace  = "knative-serving"
+	controlDeployment = "net-gateway-api-controller"
+)
+
+func TestNetGatewayAPIControlHA(t *testing.T) {
+	clients := test.Setup(t)
+	ctx := context.Background()
+
+	if err := pkgTest.WaitForDeploymentScale(ctx, clients.KubeClient, controlDeployment, controlNamespace, haReplicas); err != nil {
+		t.Fatalf("Deployment %s not scaled to %d: %v", controlDeployment, haReplicas, err)
+	}
+
+	leaders, err := pkgHa.WaitForNewLeaders(ctx, t, clients.KubeClient, controlDeployment, controlNamespace, sets.NewString(), 1 /* numBuckets */)
+	if err != nil {
+		t.Fatalf("Failed to get leader: %v", err)
+	}
+	t.Logf("Got initial leader set: %v", leaders)
+
+	svcName, svcPort, svcCancel := ingress.CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
+	defer svcCancel()
+
+	_, _, ingressCancel := ingress.CreateIngressReady(ctx, t, clients, createIngressSpec(svcName, svcPort))
+	defer ingressCancel()
+
+	url := apis.HTTP(svcName + domain)
+	prober := test.RunRouteProber(t.Logf, clients, url.URL())
+	defer test.AssertProberDefault(t, prober)
+
+	for _, leader := range leaders.List() {
+		if err := clients.KubeClient.CoreV1().Pods(controlNamespace).Delete(ctx, leader, metav1.DeleteOptions{
+			GracePeriodSeconds: ptr.Int64(0),
+		}); err != nil && !apierrs.IsNotFound(err) {
+			t.Fatalf("Failed to delete pod %s: %v", leader, err)
+		}
+
+		if err := pkgTest.WaitForPodDeleted(ctx, clients.KubeClient, leader, controlNamespace); err != nil {
+			t.Fatalf("Did not observe %s to actually be deleted: %v", leader, err)
+		}
+	}
+
+	// Wait for all of the old leaders to go away, and then for the right number to be back.
+	if _, err := pkgHa.WaitForNewLeaders(ctx, t, clients.KubeClient, controlDeployment, controlNamespace, leaders, 1 /* numBuckets */); err != nil {
+		t.Fatalf("Failed to find new leader: %v", err)
+	}
+
+	// Create a new service after electing the new leader to together with a new ingress.
+	newSvcName, newSvcPort, newSvcCancel := ingress.CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
+	defer newSvcCancel()
+
+	_, _, newIngressCancel := ingress.CreateIngressReady(ctx, t, clients, createIngressSpec(newSvcName, newSvcPort))
+	defer newIngressCancel()
+
+	// Verify the new service is accessible via the ingress.
+	assertIngressEventuallyWorks(ctx, t, clients, apis.HTTP(newSvcName+domain).URL())
+}

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ha
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/networking/test"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/spoof"
+)
+
+const (
+	haReplicas = 2
+	domain     = ".example.com"
+)
+
+func createIngressSpec(name string, port int) v1alpha1.IngressSpec {
+	return v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts: []string{name + domain},
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+		}},
+	}
+}
+
+func assertIngressEventuallyWorks(ctx context.Context, t *testing.T, clients *test.Clients, url *url.URL) {
+	t.Helper()
+	if _, err := pkgTest.WaitForEndpointState(
+		ctx,
+		clients.KubeClient,
+		t.Logf,
+		url,
+		spoof.IsStatusOK,
+		"WaitForIngressToReturnSuccess",
+		test.NetworkingFlags.ResolvableDomain); err != nil {
+		t.Fatalf("The service at %s didn't return success: %v", url, err)
+	}
+}

--- a/test/kind-e2e-contour.sh
+++ b/test/kind-e2e-contour.sh
@@ -18,6 +18,7 @@
 
 set -euo pipefail
 
+CONTROL_NAMESPACE=knative-serving
 IPS=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )
 CLUSTER_SUFFIX=${CLUSTER_SUFFIX:-cluster.local}
 UNSUPPORTED_TESTS="tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,update,host-rewrite"
@@ -49,3 +50,18 @@ go test -race -count=1 -short -timeout=20m -tags=e2e ./test/conformance \
    --ingressendpoint="${IPS[0]}" \
    --ingressClass=gateway-api.ingress.networking.knative.dev \
    --cluster-suffix=${CLUSTER_SUFFIX}
+
+# Give the controller time to sync with the rest of the system components.
+sleep 30
+
+echo ">> Scale up controller for HA tests"
+kubectl -n "${CONTROL_NAMESPACE}" scale deployment net-gateway-api-controller --replicas=2
+
+go test -count=1 -timeout=15m -failfast -parallel=1 -tags=e2e ./test/ha -spoofinterval="10ms" \
+   --enable-alpha --enable-beta \
+   --ingressendpoint="${IPS[0]}" \
+   --ingressClass=gateway-api.ingress.networking.knative.dev \
+   --cluster-suffix=${CLUSTER_SUFFIX}
+
+echo ">> Scale down after HA tests"
+kubectl -n "${CONTROL_NAMESPACE}" scale deployment net-gateway-api-controller --replicas=1

--- a/test/kind-e2e-istio.sh
+++ b/test/kind-e2e-istio.sh
@@ -18,6 +18,7 @@
 
 set -euo pipefail
 
+CONTROL_NAMESPACE=knative-serving
 IPS=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )
 CLUSTER_SUFFIX=${CLUSTER_SUFFIX:-cluster.local}
 UNSUPPORTED_TESTS="tls,retry,httpoption"
@@ -42,3 +43,18 @@ go test -race -count=1 -short -timeout=20m -tags=e2e ./test/conformance \
    --ingressendpoint="${IPS[0]}" \
    --ingressClass=gateway-api.ingress.networking.knative.dev \
    --cluster-suffix=${CLUSTER_SUFFIX}
+
+# Give the controller time to sync with the rest of the system components.
+sleep 30
+
+echo ">> Scale up controller for HA tests"
+kubectl -n "${CONTROL_NAMESPACE}" scale deployment net-gateway-api-controller --replicas=2
+
+go test -count=1 -timeout=15m -failfast -parallel=1 -tags=e2e ./test/ha -spoofinterval="10ms" \
+   --enable-alpha --enable-beta \
+   --ingressendpoint="${IPS[0]}" \
+   --ingressClass=gateway-api.ingress.networking.knative.dev \
+   --cluster-suffix=${CLUSTER_SUFFIX}
+
+echo ">> Scale down after HA tests"
+kubectl -n "${CONTROL_NAMESPACE}" scale deployment net-gateway-api-controller --replicas=1

--- a/vendor/knative.dev/pkg/test/ha/ha.go
+++ b/vendor/knative.dev/pkg/test/ha/ha.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ha
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	"knative.dev/pkg/test/logging"
+)
+
+func countingRFind(wr rune, wc int) func(rune) bool {
+	cnt := 0
+	return func(r rune) bool {
+		if r == wr {
+			cnt++
+		}
+		return cnt == wc
+	}
+}
+
+func extractDeployment(pod string) string {
+	if x := strings.LastIndexFunc(pod, countingRFind('-', 2)); x != -1 {
+		return pod[:x]
+	}
+	return ""
+}
+
+// GetLeaders collects all of the leader pods from the specified deployment.
+// GetLeaders will return duplicate pods by design.
+func GetLeaders(ctx context.Context, t *testing.T, client kubernetes.Interface, deploymentName, namespace string) ([]string, error) {
+	leases, err := client.CoordinationV1().Leases(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error getting leases for deployment %q: %w", deploymentName, err)
+	}
+	ret := make([]string, 0, len(leases.Items))
+	for _, lease := range leases.Items {
+		if lease.Spec.HolderIdentity == nil {
+			continue
+		}
+		pod := strings.SplitN(*lease.Spec.HolderIdentity, "_", 2)[0]
+
+		// Deconstruct the pod name and look for the deployment.  This won't work for very long deployment names.
+		if extractDeployment(pod) != deploymentName {
+			continue
+		}
+		ret = append(ret, pod)
+	}
+	return ret, nil
+}
+
+// WaitForNewLeaders waits until the collection of current leaders consists of "n" leaders
+// which do not include the specified prior leaders.
+func WaitForNewLeaders(ctx context.Context, t *testing.T, client kubernetes.Interface, deploymentName, namespace string, previousLeaders sets.String, n int) (sets.String, error) {
+	span := logging.GetEmitableSpan(ctx, "WaitForNewLeaders/"+deploymentName)
+	defer span.End()
+
+	var leaders sets.String
+	err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+		currLeaders, err := GetLeaders(ctx, t, client, deploymentName, namespace)
+		if err != nil {
+			return false, err
+		}
+		if len(currLeaders) < n {
+			t.Logf("WaitForNewLeaders[%s] not enough leaders, got: %d, want: %d", deploymentName, len(currLeaders), n)
+			return false, nil
+		}
+		l := sets.NewString(currLeaders...)
+		if previousLeaders.HasAny(currLeaders...) {
+			t.Logf("WaitForNewLeaders[%s] still see intersection: %v", deploymentName, previousLeaders.Intersection(l))
+			return false, nil
+		}
+		leaders = l
+		return true, nil
+	})
+	return leaders, err
+}
+
+// WaitForNewLeader waits until the holder of the given lease is different from the previousLeader.
+//
+// Deprecated: Use WaitForNewLeaders.
+func WaitForNewLeader(ctx context.Context, client kubernetes.Interface, lease, namespace, previousLeader string) (string, error) {
+	span := logging.GetEmitableSpan(ctx, "WaitForNewLeader/"+lease)
+	defer span.End()
+	var leader string
+	err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+		lease, err := client.CoordinationV1().Leases(namespace).Get(ctx, lease, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("error getting lease %s: %w", lease, err)
+		}
+		leader = strings.Split(*lease.Spec.HolderIdentity, "_")[0]
+		return leader != previousLeader, nil
+	})
+	return leader, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -851,6 +851,7 @@ knative.dev/pkg/system
 knative.dev/pkg/system/testing
 knative.dev/pkg/test
 knative.dev/pkg/test/environment
+knative.dev/pkg/test/ha
 knative.dev/pkg/test/helpers
 knative.dev/pkg/test/ingress
 knative.dev/pkg/test/logging


### PR DESCRIPTION
This patch adds HA test for net-gateway-api controller.
The logic is same with Kourier's HA test.
