### PR TITLE
Add wait_until_service_has_external_http_address

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -47,6 +47,14 @@ function test_setup() {
   # Wait for pods to be running.
   echo ">> Waiting for controller components to be running..."
   kubectl -n "${CONTROL_NAMESPACE}" rollout status deployment net-gateway-api-controller || return 1
+
+  echo ">> Bringing up Istio"
+  ./third_party/istio-head/install-istio.sh istio-ci-no-mesh.yaml
+
+  echo ">> Deploy Gateway API resources"
+  kubectl apply -f ./third_party/istio-head/gateway/
+
+  wait_until_service_has_external_http_address istio-system istio-ingressgateway
 }
 
 # Add function call to trap

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -22,12 +22,6 @@ initialize "$@" --skip-istio-addon
 UNSUPPORTED_TESTS="tls,retry,httpoption"
 failed=0
 
-echo ">> Bringing up Istio"
-./third_party/istio-head/install-istio.sh istio-ci-no-mesh.yaml
-
-echo ">> Deploy Gateway API resources"
-kubectl apply -f ./third_party/istio-head/gateway/
-
 echo ">> Running e2e tests"
 go_test_e2e -timeout=20m -tags=e2e -parallel=12 \
   ./test/conformance \


### PR DESCRIPTION
This patch adds `wait_until_service_has_external_http_address` after
deploying ingress. as nigthly build failed with the error:

[example log](https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-sandbox-net-gateway-api-nightly-release/1465245114015158272)
```
util.go:743: Service does not have a supported shape (not type LoadBalancer? missing --ingressendpoint?).
```

Also it moves all deploy commands into `test_setup()` (as other net repos do so).

/cc @markusthoemmes @ZhiminXiang @carlisia 
