### PR TITLE
Generate Gateway API CRD only when kubectl exists

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -62,5 +62,10 @@ eval "echo \"${template}\"" > ${REPO_ROOT_DIR}/docs/test-version.md
 
 group "Update gateway API CRDs"
 
-echo "# Generated with \"kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}\"" > ${REPO_ROOT_DIR}/config/100-gateway-api.yaml
-kubectl kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}" >> ${REPO_ROOT_DIR}/config/100-gateway-api.yaml
+if command -v kubectl &> /dev/null
+then
+  echo "# Generated with \"kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}\"" > ${REPO_ROOT_DIR}/config/100-gateway-api.yaml
+  kubectl kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}" >> ${REPO_ROOT_DIR}/config/100-gateway-api.yaml
+else
+  echo "Skipping: kubectl command does not exist."
+fi


### PR DESCRIPTION
As current script generates the Gateway API CRD by `kubectl kustomize`,
it fails when kubectl does not exist.
E.g. "Update Deps and Codegen" in knative-sandbox/knobots misses the command as
https://github.com/knative-sandbox/knobots/runs/4408339616?check_suite_focus=true

So this patch changes to generate the CRD only when `kubectl` command exists.