### PR TITLE
Bump istio and Contour to the 1.11.5 and 1.19.1

### DIFF
--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -15,5 +15,5 @@ The following Gateway API version and Ingress were tested as part of the release
 
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
-| Istio   | v1.11.2     | tls,retry,httpoption   |
+| Istio   | v1.11.4     | tls,retry,httpoption   |
 | Contour | v1.19.0    | tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,update,host-rewrite |

--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -15,5 +15,5 @@ The following Gateway API version and Ingress were tested as part of the release
 
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
-| Istio   | v1.11.4     | tls,retry,httpoption   |
+| Istio   | v1.11.5     | tls,retry,httpoption   |
 | Contour | v1.19.1    | tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,update,host-rewrite |

--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -16,4 +16,4 @@ The following Gateway API version and Ingress were tested as part of the release
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
 | Istio   | v1.11.4     | tls,retry,httpoption   |
-| Contour | v1.19.0    | tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,update,host-rewrite |
+| Contour | v1.19.1    | tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,update,host-rewrite |

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 export GATEWAY_API_VERSION="v0.3.0"
-export ISTIO_VERSION="1.11.2"
+export ISTIO_VERSION="1.11.4"
 export ISTIO_UNSUPPORTED_TESTS="tls,retry,httpoption"
 export CONTOUR_VERSION="v1.19.0"
 export CONTOUR_UNSUPPORTED_TESTS="tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,update,host-rewrite"

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -17,5 +17,5 @@
 export GATEWAY_API_VERSION="v0.3.0"
 export ISTIO_VERSION="1.11.4"
 export ISTIO_UNSUPPORTED_TESTS="tls,retry,httpoption"
-export CONTOUR_VERSION="v1.19.0"
+export CONTOUR_VERSION="v1.19.1"
 export CONTOUR_UNSUPPORTED_TESTS="tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,update,host-rewrite"

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 export GATEWAY_API_VERSION="v0.3.0"
-export ISTIO_VERSION="1.11.4"
+export ISTIO_VERSION="1.11.5"
 export ISTIO_UNSUPPORTED_TESTS="tls,retry,httpoption"
 export CONTOUR_VERSION="v1.19.1"
 export CONTOUR_UNSUPPORTED_TESTS="tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,update,host-rewrite"


### PR DESCRIPTION
This patch bumps Istio and Contour tested versions to the 1.11.5 and 1.19.1 before the release.