### PR TITLE
Bump k8s version to 1.23.0 in kind

### DIFF
--- a/.github/workflows/kind-conformance.yaml
+++ b/.github/workflows/kind-conformance.yaml
@@ -20,27 +20,26 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.20.7
         - v1.21.1
         - v1.22.2
+        - v1.23.0
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases
         include:
-        - k8s-version: v1.20.7
-          kind-version: v0.11.1
-          kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
-          ingress: istio
         - k8s-version: v1.21.1
           kind-version: v0.11.1
           kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
-          ingress: contour
+          ingress: istio
         - k8s-version: v1.22.2
           kind-version: v0.11.1
           kind-image-sha: sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f
+          ingress: contour
+        - k8s-version: v1.23.0
+          kind-version: v0.11.1
+          kind-image-sha: sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
           ingress: istio
-
 
 
     env:

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,25 +20,25 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.20.7
         - v1.21.1
         - v1.22.2
+        - v1.23.0
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases
         include:
-        - k8s-version: v1.20.7
-          kind-version: v0.11.1
-          kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
-          ingress: istio
         - k8s-version: v1.21.1
           kind-version: v0.11.1
           kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
-          ingress: contour
+          ingress: istio
         - k8s-version: v1.22.2
           kind-version: v0.11.1
           kind-image-sha: sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f
+          ingress: contour
+        - k8s-version: v1.23.0
+          kind-version: v0.11.1
+          kind-image-sha: sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
           ingress: istio
 
     env:


### PR DESCRIPTION
As k8s min version was bumped to 1.21 by knative/pkg#2397, this patch bumps k8s version in kind.