### PR TITLE
Bump Gateway API version to v0.4.2

### DIFF
--- a/config/100-gateway-api.yaml
+++ b/config/100-gateway-api.yaml
@@ -1,4 +1,4 @@
-# Generated with "kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0"
+# Generated with "kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.2"
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -20,7 +20,7 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.controller
+    - jsonPath: .spec.controllerName
       name: Controller
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -1392,7 +1392,7 @@ spec:
                                         of the request is used. \n Support: Core"
                                       maxLength: 253
                                       minLength: 1
-                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     port:
                                       description: "Port is the port to be used in
@@ -1765,7 +1765,7 @@ spec:
                                   \n Support: Core"
                                 maxLength: 253
                                 minLength: 1
-                                pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               port:
                                 description: "Port is the port to be used in the value
@@ -2311,6 +2311,7 @@ spec:
                   required:
                   - group
                   - kind
+                  - namespace
                   type: object
                 maxItems: 16
                 minItems: 1

--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -9,11 +9,11 @@ The following Gateway API version and Ingress were tested as part of the release
 
 | Tested Gateway API       |
 | ------------------------ |
-| v0.4.0 |
+| v0.4.2 |
 
 ### Tested Ingress
 
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
-| Istio   | v1.12.2     | tls,retry,httpoption,host-rewrite   |
-| Contour | v1.20.0    | tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite |
+| Istio   | v1.13.2     | tls,retry,httpoption,host-rewrite   |
+| Contour | v1.20.1    | tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite |

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export GATEWAY_API_VERSION="v0.4.0"
-export ISTIO_VERSION="1.12.2"
+export GATEWAY_API_VERSION="v0.4.2"
+export ISTIO_VERSION="1.13.2"
 export ISTIO_UNSUPPORTED_TESTS="tls,retry,httpoption,host-rewrite"
-export CONTOUR_VERSION="v1.20.0"
+export CONTOUR_VERSION="v1.20.1"
 export CONTOUR_UNSUPPORTED_TESTS="tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite"


### PR DESCRIPTION
This patch bumps:
- Gateway API version to v0.4.2.
- Istio to v1.13.2
- Contour to v1.20.1