### PR TITLE
Bump kind version to 0.12.0 for k8s 1.23

### DIFF
--- a/.github/workflows/kind-conformance.yaml
+++ b/.github/workflows/kind-conformance.yaml
@@ -33,7 +33,7 @@ jobs:
           ingress: istio
 
         - k8s-version: v1.23.5
-          kind-version: v0.11.1
+          kind-version: v0.12.0
           kind-image-sha: sha256:a69c29d3d502635369a5fe92d8e503c09581fcd406ba6598acc5d80ff5ba81b1
           ingress: contour
 
@@ -97,7 +97,6 @@ jobs:
         # (2) use a random cluster suffix
         kubeadmConfigPatches:
           - |
-            apiVersion: kubeadm.k8s.io/v1beta2
             kind: ClusterConfiguration
             metadata:
               name: config

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -33,7 +33,7 @@ jobs:
           ingress: istio
 
         - k8s-version: v1.23.5
-          kind-version: v0.11.1
+          kind-version: v0.12.0
           kind-image-sha: sha256:a69c29d3d502635369a5fe92d8e503c09581fcd406ba6598acc5d80ff5ba81b1
           ingress: contour
 
@@ -97,7 +97,6 @@ jobs:
         # (2) use a random cluster suffix
         kubeadmConfigPatches:
           - |
-            apiVersion: kubeadm.k8s.io/v1beta2
             kind: ClusterConfiguration
             metadata:
               name: config


### PR DESCRIPTION
This patch bumps kind version 0.12.0 for k8s 1.23.

Since an issue https://github.com/knative/networking/issues/660 exists before,
we didn't update the version but it could be fixed by
dropping `apiVersion: kubeadm.k8s.io/v1beta2` from `kubeadmConfigPatches`.