### PR TITLE
Bump Contour version to v1.21.0

### DIFF
--- a/config/100-gateway-api.yaml
+++ b/config/100-gateway-api.yaml
@@ -1,4 +1,4 @@
-# Generated with "kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.2"
+# Generated with "kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.3"
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -9,11 +9,11 @@ The following Gateway API version and Ingress were tested as part of the release
 
 | Tested Gateway API       |
 | ------------------------ |
-| v0.4.2 |
+| v0.4.3 |
 
 ### Tested Ingress
 
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
 | Istio   | v1.13.2     | tls,retry,httpoption,host-rewrite   |
-| Contour | v1.20.1    | tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite |
+| Contour | v1.21.0    | tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite |

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export GATEWAY_API_VERSION="v0.4.2"
+export GATEWAY_API_VERSION="v0.4.3"
 export ISTIO_VERSION="1.13.2"
 export ISTIO_UNSUPPORTED_TESTS="tls,retry,httpoption,host-rewrite"
-export CONTOUR_VERSION="v1.20.1"
+export CONTOUR_VERSION="v1.21.0"
 export CONTOUR_UNSUPPORTED_TESTS="tls,retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite"


### PR DESCRIPTION
This patch bumps tested contour version to 1.21.0.

gateway-api also bumps but it just includes minor change as per https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.4.3.