### PR TITLE
Bump Contour to a recent commit

### DIFF
--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -16,4 +16,4 @@ The following Gateway API version and Ingress were tested as part of the release
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
 | Istio   | v1.13.2     | retry,httpoption,host-rewrite   |
-| Contour | v1.21.0    | retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite |
+| Contour | 485238e    | retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite |

--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -16,4 +16,4 @@ The following Gateway API version and Ingress were tested as part of the release
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
 | Istio   | v1.13.2     | retry,httpoption,host-rewrite   |
-| Contour | 485238e    | retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite |
+| Contour | 8334ab9    | retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite |

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -17,5 +17,5 @@
 export GATEWAY_API_VERSION="v0.5.0-rc1"
 export ISTIO_VERSION="1.13.2"
 export ISTIO_UNSUPPORTED_E2E_TESTS="retry,httpoption,host-rewrite"
-export CONTOUR_VERSION="v1.21.0"
+export CONTOUR_VERSION="485238e"
 export CONTOUR_UNSUPPORTED_E2E_TESTS="retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite"

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -17,5 +17,5 @@
 export GATEWAY_API_VERSION="v0.5.0-rc1"
 export ISTIO_VERSION="1.13.2"
 export ISTIO_UNSUPPORTED_E2E_TESTS="retry,httpoption,host-rewrite"
-export CONTOUR_VERSION="485238e"
+export CONTOUR_VERSION="8334ab9"
 export CONTOUR_UNSUPPORTED_E2E_TESTS="retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite"


### PR DESCRIPTION
Use a recent commit of Contour in order to use the update to Gateway API v0.5.0-rc1.

Partially addresses: https://github.com/knative-sandbox/net-gateway-api/issues/308.