### PR TITLE
Bump Istio to v1.14.1

### DIFF
--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -15,5 +15,5 @@ The following Gateway API version and Ingress were tested as part of the release
 
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
-| Istio   | v1.13.2     | retry,httpoption,host-rewrite   |
+| Istio   | 1.14.1     | retry,httpoption,host-rewrite   |
 | Contour | 8334ab9    | retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite |

--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -15,5 +15,5 @@ The following Gateway API version and Ingress were tested as part of the release
 
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
-| Istio   | 1.14.1     | retry,httpoption,host-rewrite   |
+| Istio   | v1.14.1     | retry,httpoption,host-rewrite   |
 | Contour | 8334ab9    | retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite |

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 export GATEWAY_API_VERSION="v0.5.0-rc1"
-export ISTIO_VERSION="1.13.2"
+export ISTIO_VERSION="1.14.1"
 export ISTIO_UNSUPPORTED_E2E_TESTS="retry,httpoption,host-rewrite"
 export CONTOUR_VERSION="8334ab9"
 export CONTOUR_UNSUPPORTED_E2E_TESTS="retry,httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,visibility/path,visibility,update,host-rewrite"


### PR DESCRIPTION
In Draft, depends on https://github.com/knative-sandbox/net-gateway-api/pull/329?w=1.