### PR TITLE
Add debug info for prow script

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -21,6 +21,8 @@ source $(dirname $0)/../vendor/knative.dev/hack/e2e-tests.sh
 source "$(dirname $0)"/e2e-library-deployments.sh
 source "$(dirname $0)"/e2e-library.sh
 
+set +x
+
 # Script entry point.
 initialize "$@" --skip-istio-addon
 


### PR DESCRIPTION
We're seeing errors like https://storage.googleapis.com/knative-prow/logs/continuous_net-gateway-api_main_periodic/1546926961899606016/build-log.txt

I suspect _something_ related to #315 (possibly that services are being set as NodePort on GKE), but I'd like to see the commands used to set up the cluster to verify.
