### PR TITLE
Wait for loadbalancer to be "ready" before testing

### DIFF
--- a/test/e2e-library-deployments.sh
+++ b/test/e2e-library-deployments.sh
@@ -37,6 +37,10 @@ function deploy_istio() {
 
   echo ">> Deploy Gateway API resources"
   kubectl apply -f ./third_party/istio/gateway/
+
+  if [[ "$KIND" != "kind" ]]; then
+    wait_until_service_has_external_http_address istio-system istio-ingressgateway
+  fi
 }
 
 function deploy_contour() {
@@ -44,6 +48,8 @@ function deploy_contour() {
 
   echo ">> Waiting for Contour operator deployment to be available"
   kubectl wait deploy --for=condition=Available --timeout=120s -n "contour-operator" -l '!job-name'
+
+  # TODO: kind-ify this to support both LB and NodePort like Istio
 
   ko resolve -f ./third_party/contour/gateway/ | \
       sed 's/LoadBalancerService/NodePortService/g' | \


### PR DESCRIPTION
Should resolve failures like the following:

https://storage.googleapis.com/knative-prow/logs/nightly_net-gateway-api_main_periodic/1546944437685325824/build-log.txt

```
Service does not have a supported shape (not type LoadBalancer? missing --ingressendpoint?).
```

Which comes from this point here: https://github.com/knative/networking/blob/main/test/conformance/ingress/util.go#L1083

(Called from https://github.com/knative/networking/blob/main/test/conformance/ingress/util.go#L863)

/assign @carlisia
