### PR TITLE
Bump Go version to 1.18 for CI

### DIFF
--- a/.github/workflows/kind-conformance.yaml
+++ b/.github/workflows/kind-conformance.yaml
@@ -51,10 +51,10 @@ jobs:
       CLUSTER_SUFFIX: c${{ github.run_id }}.local
 
     steps:
-    - name: Set up Go 1.17.x
+    - name: Set up Go 1.18.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
 
     - name: Install Dependencies
       working-directory: ./

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -51,10 +51,10 @@ jobs:
       CLUSTER_SUFFIX: c${{ github.run_id }}.local
 
     steps:
-    - name: Set up Go 1.17.x
+    - name: Set up Go 1.18.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
 
     - name: Install Dependencies
       working-directory: ./


### PR DESCRIPTION
Same fix with https://github.com/knative-sandbox/net-kourier/pull/881.