### PR TITLE
Bump k8s version in KinD

### DIFF
--- a/.github/workflows/kind-conformance.yaml
+++ b/.github/workflows/kind-conformance.yaml
@@ -20,27 +20,27 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.22.9
-        - v1.23.6
-        - v1.24.0
+        - v1.23.12
+        - v1.24.6
+        - v1.25.2
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases
         include:
-        - k8s-version: v1.22.9
-          kind-version: v0.14.0
-          kind-image-sha: sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
+        - k8s-version: v1.23.12
+          kind-version: v0.16.0
+          kind-image-sha: sha256:9402cf1330bbd3a0d097d2033fa489b2abe40d479cc5ef47d0b6a6960613148a
           ingress: istio
 
-        - k8s-version: v1.23.6
-          kind-version: v0.14.0
-          kind-image-sha: sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
+        - k8s-version: v1.24.6
+          kind-version: v0.16.0
+          kind-image-sha: sha256:97e8d00bc37a7598a0b32d1fabd155a96355c49fa0d4d4790aab0f161bf31be1
           ingress: contour
 
-        - k8s-version: v1.24.0
-          kind-version: v0.14.0
-          kind-image-sha: sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+        - k8s-version: v1.25.2
+          kind-version: v0.16.0
+          kind-image-sha: sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace
           ingress: istio
 
     env:

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,27 +20,27 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.22.9
-        - v1.23.6
-        - v1.24.0
+        - v1.23.12
+        - v1.24.6
+        - v1.25.2
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases
         include:
-        - k8s-version: v1.22.9
-          kind-version: v0.14.0
-          kind-image-sha: sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
+        - k8s-version: v1.23.12
+          kind-version: v0.16.0
+          kind-image-sha: sha256:9402cf1330bbd3a0d097d2033fa489b2abe40d479cc5ef47d0b6a6960613148a
           ingress: istio
 
-        - k8s-version: v1.23.6
-          kind-version: v0.14.0
-          kind-image-sha: sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
+        - k8s-version: v1.24.6
+          kind-version: v0.16.0
+          kind-image-sha: sha256:97e8d00bc37a7598a0b32d1fabd155a96355c49fa0d4d4790aab0f161bf31be1
           ingress: contour
 
-        - k8s-version: v1.24.0
-          kind-version: v0.14.0
-          kind-image-sha: sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+        - k8s-version: v1.25.2
+          kind-version: v0.16.0
+          kind-image-sha: sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace
           ingress: istio
 
     env:


### PR DESCRIPTION
As per title, this patch follows up https://github.com/knative/pkg/pull/2595. 