### PR TITLE
Use v1beta1 APIs

### DIFF
--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -35,9 +35,9 @@ import (
 	"knative.dev/pkg/reconciler"
 
 	gwapiclient "knative.dev/net-gateway-api/pkg/client/injection/client"
-	gatewayinformer "knative.dev/net-gateway-api/pkg/client/injection/informers/apis/v1alpha2/gateway"
-	httprouteinformer "knative.dev/net-gateway-api/pkg/client/injection/informers/apis/v1alpha2/httproute"
-	referencepolicyinformer "knative.dev/net-gateway-api/pkg/client/injection/informers/apis/v1alpha2/referencepolicy"
+	referencegrantinformer "knative.dev/net-gateway-api/pkg/client/injection/informers/apis/v1alpha2/referencegrant"
+	gatewayinformer "knative.dev/net-gateway-api/pkg/client/injection/informers/apis/v1beta1/gateway"
+	httprouteinformer "knative.dev/net-gateway-api/pkg/client/injection/informers/apis/v1beta1/httproute"
 	"knative.dev/net-gateway-api/pkg/reconciler/ingress/config"
 )
 
@@ -56,15 +56,15 @@ func NewController(
 
 	ingressInformer := ingressinformer.Get(ctx)
 	httprouteInformer := httprouteinformer.Get(ctx)
-	referencePolicyInformer := referencepolicyinformer.Get(ctx)
+	referenceGrantInformer := referencegrantinformer.Get(ctx)
 	gatewayInformer := gatewayinformer.Get(ctx)
 	endpointsInformer := endpointsinformer.Get(ctx)
 
 	c := &Reconciler{
-		gwapiclient:           gwapiclient.Get(ctx),
-		httprouteLister:       httprouteInformer.Lister(),
-		referencePolicyLister: referencePolicyInformer.Lister(),
-		gatewayLister:         gatewayInformer.Lister(),
+		gwapiclient:          gwapiclient.Get(ctx),
+		httprouteLister:      httprouteInformer.Lister(),
+		referenceGrantLister: referenceGrantInformer.Lister(),
+		gatewayLister:        gatewayInformer.Lister(),
 	}
 
 	filterFunc := reconciler.AnnotationFilterFunc(networking.IngressClassAnnotationKey, gatewayAPIIngressClassName, false)

--- a/pkg/reconciler/ingress/controller_test.go
+++ b/pkg/reconciler/ingress/controller_test.go
@@ -26,9 +26,9 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/system"
 
-	_ "knative.dev/net-gateway-api/pkg/client/injection/informers/apis/v1alpha2/gateway/fake"
-	_ "knative.dev/net-gateway-api/pkg/client/injection/informers/apis/v1alpha2/httproute/fake"
-	_ "knative.dev/net-gateway-api/pkg/client/injection/informers/apis/v1alpha2/referencepolicy/fake"
+	_ "knative.dev/net-gateway-api/pkg/client/injection/informers/apis/v1alpha2/referencegrant/fake"
+	_ "knative.dev/net-gateway-api/pkg/client/injection/informers/apis/v1beta1/gateway/fake"
+	_ "knative.dev/net-gateway-api/pkg/client/injection/informers/apis/v1beta1/httproute/fake"
 	_ "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/ingress/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -30,9 +30,10 @@ import (
 	"knative.dev/pkg/network"
 	pkgreconciler "knative.dev/pkg/reconciler"
 
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayclientset "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
-	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1alpha2"
+	gatewayalphalisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1alpha2"
+	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1beta1"
 )
 
 const (
@@ -49,7 +50,7 @@ type Reconciler struct {
 	// Listers index properties about resources
 	httprouteLister gatewaylisters.HTTPRouteLister
 
-	referencePolicyLister gatewaylisters.ReferencePolicyLister
+	referenceGrantLister gatewayalphalisters.ReferenceGrantLister
 
 	gatewayLister gatewaylisters.GatewayLister
 }
@@ -109,7 +110,7 @@ func (c *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 		}
 	}
 
-	listeners := make([]*gatewayv1alpha2.Listener, 0, len(ing.Spec.TLS))
+	listeners := make([]*gatewayapi.Listener, 0, len(ing.Spec.TLS))
 	for _, tls := range ing.Spec.TLS {
 		tls := tls
 
@@ -158,7 +159,7 @@ func (c *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 
 // isHTTPRouteReady will check the status conditions of the ingress and return true if
 // all gateways have been admitted.
-func isHTTPRouteReady(r *gatewayv1alpha2.HTTPRoute) bool {
+func isHTTPRouteReady(r *gatewayapi.HTTPRoute) bool {
 	if r.Status.Parents == nil {
 		return false
 	}
@@ -171,9 +172,9 @@ func isHTTPRouteReady(r *gatewayv1alpha2.HTTPRoute) bool {
 	return true
 }
 
-func isGatewayAdmitted(gw gatewayv1alpha2.RouteParentStatus) bool {
+func isGatewayAdmitted(gw gatewayapi.RouteParentStatus) bool {
 	for _, condition := range gw.Conditions {
-		if condition.Type == string(gatewayv1alpha2.RouteConditionAccepted) {
+		if condition.Type == string(gatewayapi.RouteConditionAccepted) {
 			return condition.Status == metav1.ConditionTrue
 		}
 	}

--- a/pkg/reconciler/ingress/resources/helpers.go
+++ b/pkg/reconciler/ingress/resources/helpers.go
@@ -19,24 +19,16 @@ package resources
 import (
 	"sort"
 
-	gatewayv1alpa2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func namespacePtr(val gatewayv1alpa2.Namespace) *gatewayv1alpa2.Namespace {
+func ptr[T any](val T) *T {
 	return &val
 }
 
-func headerMatchTypePtr(val gatewayv1alpa2.HeaderMatchType) *gatewayv1alpa2.HeaderMatchType {
-	return &val
-}
-
-func portNumPtr(port int) *gatewayv1alpa2.PortNumber {
-	pn := gatewayv1alpa2.PortNumber(port)
+func portNumPtr(port int) *gatewayapi.PortNumber {
+	pn := gatewayapi.PortNumber(port)
 	return &pn
-}
-
-func pathMatchTypePtr(val gatewayv1alpa2.PathMatchType) *gatewayv1alpa2.PathMatchType {
-	return &val
 }
 
 // LongestHost returns the most specific host.

--- a/pkg/reconciler/ingress/resources/httproute_test.go
+++ b/pkg/reconciler/ingress/resources/httproute_test.go
@@ -30,7 +30,7 @@ import (
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/reconciler"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 const (
@@ -40,10 +40,10 @@ const (
 )
 
 var (
-	externalHost      = gatewayv1alpha2.Hostname(testHosts[0])
-	localHostShortest = gatewayv1alpha2.Hostname(testLocalHosts[0])
-	localHostShort    = gatewayv1alpha2.Hostname(testLocalHosts[1])
-	localHostFull     = gatewayv1alpha2.Hostname(testLocalHosts[2])
+	externalHost      = gatewayapi.Hostname(testHosts[0])
+	localHostShortest = gatewayapi.Hostname(testLocalHosts[0])
+	localHostShort    = gatewayapi.Hostname(testLocalHosts[1])
+	localHostFull     = gatewayapi.Hostname(testLocalHosts[2])
 
 	testLocalHosts = []string{
 		"hello-example.default",
@@ -58,7 +58,7 @@ func TestMakeHTTPRoute(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		ing      *v1alpha1.Ingress
-		expected []*gatewayv1alpha2.HTTPRoute
+		expected []*gatewayapi.HTTPRoute
 	}{
 		{
 			name: "single external domain with split and cluster local",
@@ -135,7 +135,7 @@ func TestMakeHTTPRoute(t *testing.T) {
 						},
 					}},
 			},
-			expected: []*gatewayv1alpha2.HTTPRoute{
+			expected: []*gatewayapi.HTTPRoute{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      LongestHost(testHosts),
@@ -146,23 +146,23 @@ func TestMakeHTTPRoute(t *testing.T) {
 						},
 						Annotations: map[string]string{},
 					},
-					Spec: gatewayv1alpha2.HTTPRouteSpec{
-						Hostnames: []gatewayv1alpha2.Hostname{externalHost},
-						Rules: []gatewayv1alpha2.HTTPRouteRule{{
-							BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-								BackendRef: gatewayv1alpha2.BackendRef{
-									BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-										Group: (*gatewayv1alpha2.Group)(pointer.String("")),
-										Kind:  (*gatewayv1alpha2.Kind)(pointer.String("Service")),
-										Name:  gatewayv1alpha2.ObjectName("goo"),
+					Spec: gatewayapi.HTTPRouteSpec{
+						Hostnames: []gatewayapi.Hostname{externalHost},
+						Rules: []gatewayapi.HTTPRouteRule{{
+							BackendRefs: []gatewayapi.HTTPBackendRef{{
+								BackendRef: gatewayapi.BackendRef{
+									BackendObjectReference: gatewayapi.BackendObjectReference{
+										Group: (*gatewayapi.Group)(pointer.String("")),
+										Kind:  (*gatewayapi.Kind)(pointer.String("Service")),
+										Name:  gatewayapi.ObjectName("goo"),
 										Port:  portNumPtr(123),
 									},
 									Weight: pointer.Int32(int32(12)),
 								},
-								Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-									Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-										Set: []gatewayv1alpha2.HTTPHeader{
+								Filters: []gatewayapi.HTTPRouteFilter{{
+									Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+										Set: []gatewayapi.HTTPHeader{
 											{
 												Name:  "Bleep",
 												Value: "bloop",
@@ -173,19 +173,19 @@ func TestMakeHTTPRoute(t *testing.T) {
 											},
 										}}}},
 							}, {
-								BackendRef: gatewayv1alpha2.BackendRef{
-									BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-										Group: (*gatewayv1alpha2.Group)(pointer.String("")),
-										Kind:  (*gatewayv1alpha2.Kind)(pointer.String("Service")),
+								BackendRef: gatewayapi.BackendRef{
+									BackendObjectReference: gatewayapi.BackendObjectReference{
+										Group: (*gatewayapi.Group)(pointer.String("")),
+										Kind:  (*gatewayapi.Kind)(pointer.String("Service")),
 										Port:  portNumPtr(124),
-										Name:  gatewayv1alpha2.ObjectName("doo"),
+										Name:  gatewayapi.ObjectName("doo"),
 									},
 									Weight: pointer.Int32(int32(88)),
 								},
-								Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-									Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-										Set: []gatewayv1alpha2.HTTPHeader{
+								Filters: []gatewayapi.HTTPRouteFilter{{
+									Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+										Set: []gatewayapi.HTTPHeader{
 											{
 												Name:  "Baz",
 												Value: "blurg",
@@ -193,31 +193,31 @@ func TestMakeHTTPRoute(t *testing.T) {
 										},
 									}}},
 							}},
-							Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-								Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-								RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-									Set: []gatewayv1alpha2.HTTPHeader{
+							Filters: []gatewayapi.HTTPRouteFilter{{
+								Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+								RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+									Set: []gatewayapi.HTTPHeader{
 										{
 											Name:  "Foo",
 											Value: "bar",
 										},
 									},
 								}}},
-							Matches: []gatewayv1alpha2.HTTPRouteMatch{
+							Matches: []gatewayapi.HTTPRouteMatch{
 								{
-									Path: &gatewayv1alpha2.HTTPPathMatch{
-										Type:  pathMatchTypePtr(gatewayv1alpha2.PathMatchPathPrefix),
+									Path: &gatewayapi.HTTPPathMatch{
+										Type:  ptr(gatewayapi.PathMatchPathPrefix),
 										Value: pointer.String("/"),
 									},
 								},
 							},
 						}},
-						CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayv1alpha2.ParentReference{{
-								Group:     (*gatewayv1alpha2.Group)(pointer.String("gateway.networking.k8s.io")),
-								Kind:      (*gatewayv1alpha2.Kind)(pointer.String("Gateway")),
-								Namespace: namespacePtr("test-ns"),
-								Name:      gatewayv1alpha2.ObjectName("foo"),
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{{
+								Group:     (*gatewayapi.Group)(pointer.String("gateway.networking.k8s.io")),
+								Kind:      (*gatewayapi.Kind)(pointer.String("Gateway")),
+								Namespace: ptr[gatewayapi.Namespace]("test-ns"),
+								Name:      gatewayapi.ObjectName("foo"),
 							}},
 						},
 					},
@@ -231,23 +231,23 @@ func TestMakeHTTPRoute(t *testing.T) {
 						},
 						Annotations: map[string]string{},
 					},
-					Spec: gatewayv1alpha2.HTTPRouteSpec{
-						Hostnames: []gatewayv1alpha2.Hostname{localHostShortest, localHostShort, localHostFull},
-						Rules: []gatewayv1alpha2.HTTPRouteRule{{
-							BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-								BackendRef: gatewayv1alpha2.BackendRef{
-									BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-										Group: (*gatewayv1alpha2.Group)(pointer.String("")),
-										Kind:  (*gatewayv1alpha2.Kind)(pointer.String("Service")),
-										Port:  portNumPtr(123),
-										Name:  gatewayv1alpha2.ObjectName("goo"),
+					Spec: gatewayapi.HTTPRouteSpec{
+						Hostnames: []gatewayapi.Hostname{localHostShortest, localHostShort, localHostFull},
+						Rules: []gatewayapi.HTTPRouteRule{{
+							BackendRefs: []gatewayapi.HTTPBackendRef{{
+								BackendRef: gatewayapi.BackendRef{
+									BackendObjectReference: gatewayapi.BackendObjectReference{
+										Group: (*gatewayapi.Group)(pointer.String("")),
+										Kind:  (*gatewayapi.Kind)(pointer.String("Service")),
+										Port:  ptr[gatewayapi.PortNumber](123),
+										Name:  gatewayapi.ObjectName("goo"),
 									},
 									Weight: pointer.Int32(int32(12)),
 								},
-								Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-									Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-										Set: []gatewayv1alpha2.HTTPHeader{
+								Filters: []gatewayapi.HTTPRouteFilter{{
+									Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+										Set: []gatewayapi.HTTPHeader{
 											{
 												Name:  "Bleep",
 												Value: "bloop",
@@ -258,19 +258,19 @@ func TestMakeHTTPRoute(t *testing.T) {
 											},
 										}}}},
 							}, {
-								BackendRef: gatewayv1alpha2.BackendRef{
-									BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-										Group: (*gatewayv1alpha2.Group)(pointer.String("")),
-										Kind:  (*gatewayv1alpha2.Kind)(pointer.String("Service")),
+								BackendRef: gatewayapi.BackendRef{
+									BackendObjectReference: gatewayapi.BackendObjectReference{
+										Group: (*gatewayapi.Group)(pointer.String("")),
+										Kind:  (*gatewayapi.Kind)(pointer.String("Service")),
 										Port:  portNumPtr(124),
-										Name:  gatewayv1alpha2.ObjectName("doo"),
+										Name:  gatewayapi.ObjectName("doo"),
 									},
 									Weight: pointer.Int32(int32(88)),
 								},
-								Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-									Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-										Set: []gatewayv1alpha2.HTTPHeader{
+								Filters: []gatewayapi.HTTPRouteFilter{{
+									Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+										Set: []gatewayapi.HTTPHeader{
 											{
 												Name:  "Baz",
 												Value: "blurg",
@@ -278,29 +278,29 @@ func TestMakeHTTPRoute(t *testing.T) {
 										},
 									}}},
 							}},
-							Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-								Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-								RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-									Set: []gatewayv1alpha2.HTTPHeader{
+							Filters: []gatewayapi.HTTPRouteFilter{{
+								Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+								RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+									Set: []gatewayapi.HTTPHeader{
 										{
 											Name:  "Foo",
 											Value: "bar",
 										},
 									},
 								}}},
-							Matches: []gatewayv1alpha2.HTTPRouteMatch{{
-								Path: &gatewayv1alpha2.HTTPPathMatch{
-									Type:  pathMatchTypePtr(gatewayv1alpha2.PathMatchPathPrefix),
+							Matches: []gatewayapi.HTTPRouteMatch{{
+								Path: &gatewayapi.HTTPPathMatch{
+									Type:  ptr(gatewayapi.PathMatchPathPrefix),
 									Value: pointer.String("/"),
 								},
 							}},
 						}},
-						CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayv1alpha2.ParentReference{{
-								Group:     (*gatewayv1alpha2.Group)(pointer.String("gateway.networking.k8s.io")),
-								Kind:      (*gatewayv1alpha2.Kind)(pointer.String("Gateway")),
-								Namespace: namespacePtr("test-ns"),
-								Name:      gatewayv1alpha2.ObjectName("foo-local"),
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{{
+								Group:     (*gatewayapi.Group)(pointer.String("gateway.networking.k8s.io")),
+								Kind:      (*gatewayapi.Kind)(pointer.String("Gateway")),
+								Namespace: ptr[gatewayapi.Namespace]("test-ns"),
+								Name:      gatewayapi.ObjectName("foo-local"),
 							}},
 						},
 					},
@@ -351,7 +351,7 @@ func TestMakeHTTPRoute(t *testing.T) {
 					},
 				}}},
 			},
-			expected: []*gatewayv1alpha2.HTTPRoute{{
+			expected: []*gatewayapi.HTTPRoute{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      LongestHost(testHosts),
 					Namespace: testNamespace,
@@ -361,73 +361,73 @@ func TestMakeHTTPRoute(t *testing.T) {
 					},
 					Annotations: map[string]string{},
 				},
-				Spec: gatewayv1alpha2.HTTPRouteSpec{
-					Hostnames: []gatewayv1alpha2.Hostname{externalHost},
-					Rules: []gatewayv1alpha2.HTTPRouteRule{
+				Spec: gatewayapi.HTTPRouteSpec{
+					Hostnames: []gatewayapi.Hostname{externalHost},
+					Rules: []gatewayapi.HTTPRouteRule{
 						{
-							BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-								BackendRef: gatewayv1alpha2.BackendRef{
-									BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-										Group: (*gatewayv1alpha2.Group)(pointer.String("")),
-										Kind:  (*gatewayv1alpha2.Kind)(pointer.String("Service")),
+							BackendRefs: []gatewayapi.HTTPBackendRef{{
+								BackendRef: gatewayapi.BackendRef{
+									BackendObjectReference: gatewayapi.BackendObjectReference{
+										Group: (*gatewayapi.Group)(pointer.String("")),
+										Kind:  (*gatewayapi.Kind)(pointer.String("Service")),
 										Port:  portNumPtr(123),
-										Name:  gatewayv1alpha2.ObjectName("goo"),
+										Name:  gatewayapi.ObjectName("goo"),
 									},
 									Weight: pointer.Int32(int32(100)),
 								},
-								Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-									Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-										Set: []gatewayv1alpha2.HTTPHeader{}}}},
+								Filters: []gatewayapi.HTTPRouteFilter{{
+									Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+										Set: []gatewayapi.HTTPHeader{}}}},
 							}},
-							Matches: []gatewayv1alpha2.HTTPRouteMatch{
+							Matches: []gatewayapi.HTTPRouteMatch{
 								{
-									Path: &gatewayv1alpha2.HTTPPathMatch{
-										Type:  pathMatchTypePtr(gatewayv1alpha2.PathMatchPathPrefix),
+									Path: &gatewayapi.HTTPPathMatch{
+										Type:  ptr(gatewayapi.PathMatchPathPrefix),
 										Value: pointer.String("/"),
 									},
-									Headers: []gatewayv1alpha2.HTTPHeaderMatch{{
-										Type:  headerMatchTypePtr(gatewayv1alpha2.HeaderMatchExact),
-										Name:  gatewayv1alpha2.HTTPHeaderName("tag"),
+									Headers: []gatewayapi.HTTPHeaderMatch{{
+										Type:  ptr(gatewayapi.HeaderMatchExact),
+										Name:  gatewayapi.HTTPHeaderName("tag"),
 										Value: "goo",
 									}},
 								}},
 						}, {
-							BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-								BackendRef: gatewayv1alpha2.BackendRef{
-									BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-										Group: (*gatewayv1alpha2.Group)(pointer.String("")),
-										Kind:  (*gatewayv1alpha2.Kind)(pointer.String("Service")),
+							BackendRefs: []gatewayapi.HTTPBackendRef{{
+								BackendRef: gatewayapi.BackendRef{
+									BackendObjectReference: gatewayapi.BackendObjectReference{
+										Group: (*gatewayapi.Group)(pointer.String("")),
+										Kind:  (*gatewayapi.Kind)(pointer.String("Service")),
 										Port:  portNumPtr(124),
-										Name:  gatewayv1alpha2.ObjectName("doo"),
+										Name:  gatewayapi.ObjectName("doo"),
 									},
 									Weight: pointer.Int32(int32(100)),
 								},
-								Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-									Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-										Set: []gatewayv1alpha2.HTTPHeader{}}}},
+								Filters: []gatewayapi.HTTPRouteFilter{{
+									Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+										Set: []gatewayapi.HTTPHeader{}}}},
 							}},
-							Matches: []gatewayv1alpha2.HTTPRouteMatch{
+							Matches: []gatewayapi.HTTPRouteMatch{
 								{
-									Path: &gatewayv1alpha2.HTTPPathMatch{
-										Type:  pathMatchTypePtr(gatewayv1alpha2.PathMatchPathPrefix),
+									Path: &gatewayapi.HTTPPathMatch{
+										Type:  ptr(gatewayapi.PathMatchPathPrefix),
 										Value: pointer.String("/doo"),
 									},
-									Headers: []gatewayv1alpha2.HTTPHeaderMatch{{
-										Type:  headerMatchTypePtr(gatewayv1alpha2.HeaderMatchExact),
-										Name:  gatewayv1alpha2.HTTPHeaderName("tag"),
+									Headers: []gatewayapi.HTTPHeaderMatch{{
+										Type:  ptr(gatewayapi.HeaderMatchExact),
+										Name:  gatewayapi.HTTPHeaderName("tag"),
 										Value: "doo",
 									}},
 								}},
 						},
 					},
-					CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayv1alpha2.ParentReference{{
-							Group:     (*gatewayv1alpha2.Group)(pointer.String("gateway.networking.k8s.io")),
-							Kind:      (*gatewayv1alpha2.Kind)(pointer.String("Gateway")),
-							Namespace: namespacePtr("test-ns"),
-							Name:      gatewayv1alpha2.ObjectName("foo"),
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{{
+							Group:     (*gatewayapi.Group)(pointer.String("gateway.networking.k8s.io")),
+							Kind:      (*gatewayapi.Kind)(pointer.String("Gateway")),
+							Namespace: ptr[gatewayapi.Namespace]("test-ns"),
+							Name:      gatewayapi.ObjectName("foo"),
 						}},
 					},
 				},

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -29,8 +29,10 @@ import (
 	"knative.dev/pkg/reconciler/testing"
 
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	fakegatewayapiclientset "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
-	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1alpha2"
+	gatewaylistersalpha "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1alpha2"
+	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1beta1"
 )
 
 var clientSetSchemes = []func(*runtime.Scheme) error{
@@ -92,7 +94,7 @@ func (l *Listers) GetIngressLister() networkinglisters.IngressLister {
 
 // GetHTTPRouteLister get lister for HTTPProxy resource.
 func (l *Listers) GetHTTPRouteLister() gatewaylisters.HTTPRouteLister {
-	return gatewaylisters.NewHTTPRouteLister(l.IndexerFor(&gatewayv1alpha2.HTTPRoute{}))
+	return gatewaylisters.NewHTTPRouteLister(l.IndexerFor(&gatewayv1beta1.HTTPRoute{}))
 }
 
 // GetEndpointsLister get lister for K8s Endpoints resource.
@@ -101,9 +103,9 @@ func (l *Listers) GetEndpointsLister() corev1listers.EndpointsLister {
 }
 
 func (l *Listers) GetGatewayLister() gatewaylisters.GatewayLister {
-	return gatewaylisters.NewGatewayLister(l.IndexerFor(&gatewayv1alpha2.Gateway{}))
+	return gatewaylisters.NewGatewayLister(l.IndexerFor(&gatewayv1beta1.Gateway{}))
 }
 
-func (l *Listers) GetReferencePolicyLister() gatewaylisters.ReferencePolicyLister {
-	return gatewaylisters.NewReferencePolicyLister(l.IndexerFor(&gatewayv1alpha2.ReferencePolicy{}))
+func (l *Listers) GetReferenceGrantLister() gatewaylistersalpha.ReferenceGrantLister {
+	return gatewaylistersalpha.NewReferenceGrantLister(l.IndexerFor(&gatewayv1alpha2.ReferenceGrant{}))
 }

--- a/test/clients.go
+++ b/test/clients.go
@@ -27,7 +27,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 	"sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1beta1"
 )
 
 // Clients holds instances of interfaces for making requests to Knative Serving.
@@ -40,7 +40,7 @@ type Clients struct {
 // GatewayAPIClients holds instances of interfaces for making requests to Knative
 // networking clients.
 type GatewayAPIClients struct {
-	HTTPRoutes gatewayv1alpha2.HTTPRouteInterface
+	HTTPRoutes gatewayapi.HTTPRouteInterface
 }
 
 // NewClientsFromConfig instantiates and returns several clientsets required for making request to the
@@ -82,6 +82,6 @@ func newGatewayAPIClients(cfg *rest.Config, namespace string) (*GatewayAPIClient
 		return nil, err
 	}
 	return &GatewayAPIClients{
-		HTTPRoutes: cs.GatewayV1alpha2().HTTPRoutes(namespace),
+		HTTPRoutes: cs.GatewayV1beta1().HTTPRoutes(namespace),
 	}, nil
 }

--- a/test/conformance/gateway-api/basic.go
+++ b/test/conformance/gateway-api/basic.go
@@ -22,7 +22,7 @@ import (
 
 	"knative.dev/net-gateway-api/test"
 	"knative.dev/networking/pkg/apis/networking"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // TestBasics verifies that a no frills HTTPRoute exposes a simple Pod/Service via the public load balancer.
@@ -32,17 +32,17 @@ func TestBasics(t *testing.T) {
 
 	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
 
-	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(name + ".example.com")},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{{
-			BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-				BackendRef: gatewayv1alpha2.BackendRef{
-					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(name + ".example.com")},
+		Rules: []gatewayapi.HTTPRouteRule{{
+			BackendRefs: []gatewayapi.HTTPBackendRef{{
+				BackendRef: gatewayapi.BackendRef{
+					BackendObjectReference: gatewayapi.BackendObjectReference{
 						Port: portNumPtr(port),
-						Name: gatewayv1alpha2.ObjectName(name),
+						Name: gatewayapi.ObjectName(name),
 					}}},
 			},
 		}},
@@ -59,17 +59,17 @@ func TestBasicsHTTP2(t *testing.T) {
 
 	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameH2C)
 
-	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(name + ".example.com")},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{{
-			BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-				BackendRef: gatewayv1alpha2.BackendRef{
-					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(name + ".example.com")},
+		Rules: []gatewayapi.HTTPRouteRule{{
+			BackendRefs: []gatewayapi.HTTPBackendRef{{
+				BackendRef: gatewayapi.BackendRef{
+					BackendObjectReference: gatewayapi.BackendObjectReference{
 						Port: portNumPtr(port),
-						Name: gatewayv1alpha2.ObjectName(name),
+						Name: gatewayapi.ObjectName(name),
 					}}},
 			},
 		}},

--- a/test/conformance/gateway-api/grpc.go
+++ b/test/conformance/gateway-api/grpc.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/utils/pointer"
 	"knative.dev/net-gateway-api/test"
 	ping "knative.dev/networking/test/test_images/grpc-ping/proto"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // TestGRPC verifies that GRPC may be used via a simple Ingress.
@@ -47,17 +47,17 @@ func TestGRPC(t *testing.T) {
 	domain := name + ".example.com"
 
 	// Create a simple Ingress over the Service.
-	_, dialCtx, _ := createHTTPRouteReadyDialContext(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, dialCtx, _ := createHTTPRouteReadyDialContext(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(domain)},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{{
-			BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-				BackendRef: gatewayv1alpha2.BackendRef{
-					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(domain)},
+		Rules: []gatewayapi.HTTPRouteRule{{
+			BackendRefs: []gatewayapi.HTTPBackendRef{{
+				BackendRef: gatewayapi.BackendRef{
+					BackendObjectReference: gatewayapi.BackendObjectReference{
 						Port: portNumPtr(port),
-						Name: gatewayv1alpha2.ObjectName(name),
+						Name: gatewayapi.ObjectName(name),
 					}}},
 			},
 		}},
@@ -111,27 +111,27 @@ func TestGRPCSplit(t *testing.T) {
 	// Create a simple Ingress over the Service.
 	name := test.ObjectNameForTest(t)
 	domain := name + ".example.com"
-	_, dialCtx, _ := createHTTPRouteReadyDialContext(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, dialCtx, _ := createHTTPRouteReadyDialContext(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(name + ".example.com")},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{{
-			BackendRefs: []gatewayv1alpha2.HTTPBackendRef{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(name + ".example.com")},
+		Rules: []gatewayapi.HTTPRouteRule{{
+			BackendRefs: []gatewayapi.HTTPBackendRef{
 				{
-					BackendRef: gatewayv1alpha2.BackendRef{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+					BackendRef: gatewayapi.BackendRef{
+						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Port: portNumPtr(bluePort),
-							Name: gatewayv1alpha2.ObjectName(blueName),
+							Name: gatewayapi.ObjectName(blueName),
 						},
 						Weight: pointer.Int32(1),
 					},
 				},
 				{
-					BackendRef: gatewayv1alpha2.BackendRef{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+					BackendRef: gatewayapi.BackendRef{
+						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Port: portNumPtr(greenPort),
-							Name: gatewayv1alpha2.ObjectName(greenName),
+							Name: gatewayapi.ObjectName(greenName),
 						},
 						Weight: pointer.Int32(1),
 					},

--- a/test/conformance/gateway-api/headers.go
+++ b/test/conformance/gateway-api/headers.go
@@ -28,7 +28,7 @@ import (
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/http/header"
 	"knative.dev/pkg/ptr"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // TestTagHeaders verifies that an Ingress properly dispatches to backends based on the tag header
@@ -48,31 +48,31 @@ func TestTagHeaders(t *testing.T) {
 		backendWithoutTag = "no-tag"
 	)
 
-	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(name + ".example.com")},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(name + ".example.com")},
+		Rules: []gatewayapi.HTTPRouteRule{
 			{
-				BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-					BackendRef: gatewayv1alpha2.BackendRef{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+				BackendRefs: []gatewayapi.HTTPBackendRef{{
+					BackendRef: gatewayapi.BackendRef{
+						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Port: portNumPtr(port),
-							Name: gatewayv1alpha2.ObjectName(name),
+							Name: gatewayapi.ObjectName(name),
 						}}},
 				},
-				Matches: []gatewayv1alpha2.HTTPRouteMatch{{
-					Headers: []gatewayv1alpha2.HTTPHeaderMatch{{
-						Type:  headerMatchTypePtr(gatewayv1alpha2.HeaderMatchExact),
+				Matches: []gatewayapi.HTTPRouteMatch{{
+					Headers: []gatewayapi.HTTPHeaderMatch{{
+						Type:  headerMatchTypePtr(gatewayapi.HeaderMatchExact),
 						Name:  header.RouteTagKey,
 						Value: tagName,
 					}},
 				}},
-				Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-					Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-					RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-						Set: []gatewayv1alpha2.HTTPHeader{{
+				Filters: []gatewayapi.HTTPRouteFilter{{
+					Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+					RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+						Set: []gatewayapi.HTTPHeader{{
 							Name:  backendHeader,
 							Value: backendWithTag,
 						}},
@@ -80,17 +80,17 @@ func TestTagHeaders(t *testing.T) {
 				},
 			},
 			{
-				BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-					BackendRef: gatewayv1alpha2.BackendRef{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+				BackendRefs: []gatewayapi.HTTPBackendRef{{
+					BackendRef: gatewayapi.BackendRef{
+						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Port: portNumPtr(port),
-							Name: gatewayv1alpha2.ObjectName(name),
+							Name: gatewayapi.ObjectName(name),
 						}}},
 				},
-				Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-					Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-					RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-						Set: []gatewayv1alpha2.HTTPHeader{{
+				Filters: []gatewayapi.HTTPRouteFilter{{
+					Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+					RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+						Set: []gatewayapi.HTTPHeader{{
 							Name:  backendHeader,
 							Value: backendWithoutTag,
 						}},
@@ -159,23 +159,23 @@ func TestPreSplitSetHeaders(t *testing.T) {
 
 	const headerName = "Foo-Bar-Baz"
 
-	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(name + ".example.com")},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{{
-			BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-				BackendRef: gatewayv1alpha2.BackendRef{
-					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(name + ".example.com")},
+		Rules: []gatewayapi.HTTPRouteRule{{
+			BackendRefs: []gatewayapi.HTTPBackendRef{{
+				BackendRef: gatewayapi.BackendRef{
+					BackendObjectReference: gatewayapi.BackendObjectReference{
 						Port: portNumPtr(port),
-						Name: gatewayv1alpha2.ObjectName(name),
+						Name: gatewayapi.ObjectName(name),
 					}}},
 			},
-			Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-				Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-				RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-					Set: []gatewayv1alpha2.HTTPHeader{{
+			Filters: []gatewayapi.HTTPRouteFilter{{
+				Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+					Set: []gatewayapi.HTTPHeader{{
 						Name:  headerName,
 						Value: name,
 					}},
@@ -225,25 +225,25 @@ func TestPostSplitSetHeaders(t *testing.T) {
 		maxRequests = 100
 	)
 
-	backendRefs := make([]gatewayv1alpha2.HTTPBackendRef, 0, splits)
+	backendRefs := make([]gatewayapi.HTTPBackendRef, 0, splits)
 
 	names := make(sets.String, splits)
 	for i := 0; i < splits; i++ {
 		name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
 
 		backendRefs = append(backendRefs,
-			gatewayv1alpha2.HTTPBackendRef{
-				BackendRef: gatewayv1alpha2.BackendRef{
-					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+			gatewayapi.HTTPBackendRef{
+				BackendRef: gatewayapi.BackendRef{
+					BackendObjectReference: gatewayapi.BackendObjectReference{
 						Port: portNumPtr(port),
-						Name: gatewayv1alpha2.ObjectName(name),
+						Name: gatewayapi.ObjectName(name),
 					},
 					Weight: pointer.Int32(100 / splits),
 				},
-				Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-					Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-					RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-						Set: []gatewayv1alpha2.HTTPHeader{{
+				Filters: []gatewayapi.HTTPRouteFilter{{
+					Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+					RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+						Set: []gatewayapi.HTTPHeader{{
 							Name:  headerName,
 							Value: name,
 						}},
@@ -255,12 +255,12 @@ func TestPostSplitSetHeaders(t *testing.T) {
 
 	// Create a simple Ingress over the 10 Services.
 	name := test.ObjectNameForTest(t)
-	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(name + ".example.com")},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(name + ".example.com")},
+		Rules: []gatewayapi.HTTPRouteRule{{
 			BackendRefs: backendRefs,
 		}},
 	})

--- a/test/conformance/gateway-api/hosts.go
+++ b/test/conformance/gateway-api/hosts.go
@@ -22,7 +22,7 @@ import (
 
 	"knative.dev/net-gateway-api/test"
 	"knative.dev/networking/pkg/apis/networking"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // TestMultipleHosts verifies that an Ingress can respond to multiple hosts.
@@ -32,7 +32,7 @@ func TestMultipleHosts(t *testing.T) {
 
 	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
 
-	hosts := []gatewayv1alpha2.Hostname{
+	hosts := []gatewayapi.Hostname{
 		"foo.com",
 		"www.foo.com",
 		"a-b-1.something-really-really-long.knative.dev",
@@ -42,21 +42,21 @@ func TestMultipleHosts(t *testing.T) {
 	// Using fixed hostnames can lead to conflicts when -count=N>1
 	// so pseudo-randomize the hostnames to avoid conflicts.
 	for i, host := range hosts {
-		hosts[i] = gatewayv1alpha2.Hostname(name + "." + string(host))
+		hosts[i] = gatewayapi.Hostname(name + "." + string(host))
 	}
 
 	// Create a simple HTTPRoute over the Service.
-	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
 		Hostnames: hosts,
-		Rules: []gatewayv1alpha2.HTTPRouteRule{{
-			BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-				BackendRef: gatewayv1alpha2.BackendRef{
-					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+		Rules: []gatewayapi.HTTPRouteRule{{
+			BackendRefs: []gatewayapi.HTTPBackendRef{{
+				BackendRef: gatewayapi.BackendRef{
+					BackendObjectReference: gatewayapi.BackendObjectReference{
 						Port: portNumPtr(port),
-						Name: gatewayv1alpha2.ObjectName(name),
+						Name: gatewayapi.ObjectName(name),
 					}}},
 			},
 		}},

--- a/test/conformance/gateway-api/path.go
+++ b/test/conformance/gateway-api/path.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/utils/pointer"
 	"knative.dev/net-gateway-api/test"
 	"knative.dev/networking/pkg/apis/networking"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // TestPath verifies that an Ingress properly dispatches to backends based on the path of the URL.
@@ -49,103 +49,103 @@ func TestPath(t *testing.T) {
 	// Use a post-split injected header to establish which split we are sending traffic to.
 	const headerName = "Which-Backend"
 
-	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(name + ".example.com")},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(name + ".example.com")},
+		Rules: []gatewayapi.HTTPRouteRule{
 			{
-				BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-					BackendRef: gatewayv1alpha2.BackendRef{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+				BackendRefs: []gatewayapi.HTTPBackendRef{{
+					BackendRef: gatewayapi.BackendRef{
+						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Port: portNumPtr(fooPort),
-							Name: gatewayv1alpha2.ObjectName(fooName),
+							Name: gatewayapi.ObjectName(fooName),
 						}},
 					// Append different headers to each split, which lets us identify
 					// which backend we hit.
-					Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-						Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-						RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-							Set: []gatewayv1alpha2.HTTPHeader{{
+					Filters: []gatewayapi.HTTPRouteFilter{{
+						Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+							Set: []gatewayapi.HTTPHeader{{
 								Name:  headerName,
 								Value: fooName,
 							}},
 						}},
 					},
 				}},
-				Matches: []gatewayv1alpha2.HTTPRouteMatch{{
-					Path: &gatewayv1alpha2.HTTPPathMatch{
-						Type:  pathMatchTypePtr(gatewayv1alpha2.PathMatchPathPrefix),
+				Matches: []gatewayapi.HTTPRouteMatch{{
+					Path: &gatewayapi.HTTPPathMatch{
+						Type:  pathMatchTypePtr(gatewayapi.PathMatchPathPrefix),
 						Value: pointer.String("/foo"),
 					},
 				}},
 			},
 			{
-				BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-					BackendRef: gatewayv1alpha2.BackendRef{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+				BackendRefs: []gatewayapi.HTTPBackendRef{{
+					BackendRef: gatewayapi.BackendRef{
+						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Port: portNumPtr(barPort),
-							Name: gatewayv1alpha2.ObjectName(barName),
+							Name: gatewayapi.ObjectName(barName),
 						}},
 					// Append different headers to each split, which lets us identify
 					// which backend we hit.
-					Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-						Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-						RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-							Set: []gatewayv1alpha2.HTTPHeader{{
+					Filters: []gatewayapi.HTTPRouteFilter{{
+						Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+							Set: []gatewayapi.HTTPHeader{{
 								Name:  headerName,
 								Value: barName,
 							}},
 						}},
 					},
 				}},
-				Matches: []gatewayv1alpha2.HTTPRouteMatch{{
-					Path: &gatewayv1alpha2.HTTPPathMatch{
-						Type:  pathMatchTypePtr(gatewayv1alpha2.PathMatchPathPrefix),
+				Matches: []gatewayapi.HTTPRouteMatch{{
+					Path: &gatewayapi.HTTPPathMatch{
+						Type:  pathMatchTypePtr(gatewayapi.PathMatchPathPrefix),
 						Value: pointer.String("/bar"),
 					},
 				}},
 			},
 			{
-				BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-					BackendRef: gatewayv1alpha2.BackendRef{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+				BackendRefs: []gatewayapi.HTTPBackendRef{{
+					BackendRef: gatewayapi.BackendRef{
+						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Port: portNumPtr(bazPort),
-							Name: gatewayv1alpha2.ObjectName(bazName),
+							Name: gatewayapi.ObjectName(bazName),
 						}},
 					// Append different headers to each split, which lets us identify
 					// which backend we hit.
-					Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-						Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-						RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-							Set: []gatewayv1alpha2.HTTPHeader{{
+					Filters: []gatewayapi.HTTPRouteFilter{{
+						Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+							Set: []gatewayapi.HTTPHeader{{
 								Name:  headerName,
 								Value: bazName,
 							}},
 						}},
 					},
 				}},
-				Matches: []gatewayv1alpha2.HTTPRouteMatch{{
-					Path: &gatewayv1alpha2.HTTPPathMatch{
-						Type:  pathMatchTypePtr(gatewayv1alpha2.PathMatchPathPrefix),
+				Matches: []gatewayapi.HTTPRouteMatch{{
+					Path: &gatewayapi.HTTPPathMatch{
+						Type:  pathMatchTypePtr(gatewayapi.PathMatchPathPrefix),
 						Value: pointer.String("/baz"),
 					},
 				}},
 			},
 			{
-				BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-					BackendRef: gatewayv1alpha2.BackendRef{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+				BackendRefs: []gatewayapi.HTTPBackendRef{{
+					BackendRef: gatewayapi.BackendRef{
+						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Port: portNumPtr(port),
-							Name: gatewayv1alpha2.ObjectName(name),
+							Name: gatewayapi.ObjectName(name),
 						}},
 					// Append different headers to each split, which lets us identify
 					// which backend we hit.
-					Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-						Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-						RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-							Set: []gatewayv1alpha2.HTTPHeader{{
+					Filters: []gatewayapi.HTTPRouteFilter{{
+						Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+							Set: []gatewayapi.HTTPHeader{{
 								Name:  headerName,
 								Value: name,
 							}},
@@ -195,26 +195,26 @@ func TestPathAndPercentageSplit(t *testing.T) {
 	// Use a post-split injected header to establish which split we are sending traffic to.
 	const headerName = "Which-Backend"
 
-	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(name + ".example.com")},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(name + ".example.com")},
+		Rules: []gatewayapi.HTTPRouteRule{
 			{
-				BackendRefs: []gatewayv1alpha2.HTTPBackendRef{
+				BackendRefs: []gatewayapi.HTTPBackendRef{
 					{
-						BackendRef: gatewayv1alpha2.BackendRef{
-							BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+						BackendRef: gatewayapi.BackendRef{
+							BackendObjectReference: gatewayapi.BackendObjectReference{
 								Port: portNumPtr(fooPort),
-								Name: gatewayv1alpha2.ObjectName(fooName),
+								Name: gatewayapi.ObjectName(fooName),
 							},
 							Weight: pointer.Int32(1),
 						},
-						Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-							Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-								Set: []gatewayv1alpha2.HTTPHeader{{
+						Filters: []gatewayapi.HTTPRouteFilter{{
+							Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+							RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+								Set: []gatewayapi.HTTPHeader{{
 									Name:  headerName,
 									Value: fooName,
 								}},
@@ -222,17 +222,17 @@ func TestPathAndPercentageSplit(t *testing.T) {
 						},
 					},
 					{
-						BackendRef: gatewayv1alpha2.BackendRef{
-							BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+						BackendRef: gatewayapi.BackendRef{
+							BackendObjectReference: gatewayapi.BackendObjectReference{
 								Port: portNumPtr(barPort),
-								Name: gatewayv1alpha2.ObjectName(barName),
+								Name: gatewayapi.ObjectName(barName),
 							},
 							Weight: pointer.Int32(1),
 						},
-						Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-							Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-								Set: []gatewayv1alpha2.HTTPHeader{{
+						Filters: []gatewayapi.HTTPRouteFilter{{
+							Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+							RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+								Set: []gatewayapi.HTTPHeader{{
 									Name:  headerName,
 									Value: barName,
 								}},
@@ -240,26 +240,26 @@ func TestPathAndPercentageSplit(t *testing.T) {
 						},
 					},
 				},
-				Matches: []gatewayv1alpha2.HTTPRouteMatch{{
-					Path: &gatewayv1alpha2.HTTPPathMatch{
-						Type:  pathMatchTypePtr(gatewayv1alpha2.PathMatchPathPrefix),
+				Matches: []gatewayapi.HTTPRouteMatch{{
+					Path: &gatewayapi.HTTPPathMatch{
+						Type:  pathMatchTypePtr(gatewayapi.PathMatchPathPrefix),
 						Value: pointer.String("/foo"),
 					},
 				}},
 			},
 			{
-				BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-					BackendRef: gatewayv1alpha2.BackendRef{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+				BackendRefs: []gatewayapi.HTTPBackendRef{{
+					BackendRef: gatewayapi.BackendRef{
+						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Port: portNumPtr(port),
-							Name: gatewayv1alpha2.ObjectName(name),
+							Name: gatewayapi.ObjectName(name),
 						}},
 					// Append different headers to each split, which lets us identify
 					// which backend we hit.
-					Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-						Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-						RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-							Set: []gatewayv1alpha2.HTTPHeader{{
+					Filters: []gatewayapi.HTTPRouteFilter{{
+						Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+							Set: []gatewayapi.HTTPHeader{{
 								Name:  headerName,
 								Value: name,
 							}},

--- a/test/conformance/gateway-api/percentage.go
+++ b/test/conformance/gateway-api/percentage.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"knative.dev/net-gateway-api/test"
 	"knative.dev/networking/pkg/apis/networking"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // TestPercentage verifies that an Ingress splitting over multiple backends respects
@@ -37,7 +37,7 @@ func TestPercentage(t *testing.T) {
 	// Use a post-split injected header to establish which split we are sending traffic to.
 	const headerName = "Foo-Bar-Baz"
 
-	backends := make([]gatewayv1alpha2.HTTPBackendRef, 0, 10)
+	backends := make([]gatewayapi.HTTPBackendRef, 0, 10)
 	weights := make(map[string]float64, len(backends))
 
 	// Double the percentage of the split each iteration until it would overflow, and then
@@ -47,20 +47,20 @@ func TestPercentage(t *testing.T) {
 		weight := percent
 		name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
 		backends = append(backends,
-			gatewayv1alpha2.HTTPBackendRef{
-				BackendRef: gatewayv1alpha2.BackendRef{
-					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+			gatewayapi.HTTPBackendRef{
+				BackendRef: gatewayapi.BackendRef{
+					BackendObjectReference: gatewayapi.BackendObjectReference{
 						Port: portNumPtr(port),
-						Name: gatewayv1alpha2.ObjectName(name),
+						Name: gatewayapi.ObjectName(name),
 					},
 					Weight: &weight,
 				},
 				// Append different headers to each split, which lets us identify
 				// which backend we hit.
-				Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-					Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-					RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-						Set: []gatewayv1alpha2.HTTPHeader{{
+				Filters: []gatewayapi.HTTPRouteFilter{{
+					Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+					RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+						Set: []gatewayapi.HTTPHeader{{
 							Name:  headerName,
 							Value: name,
 						}},
@@ -80,12 +80,12 @@ func TestPercentage(t *testing.T) {
 
 	// Create a simple HTTPRoute over the 10 Services.
 	name := test.ObjectNameForTest(t)
-	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(name + ".example.com")},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(name + ".example.com")},
+		Rules: []gatewayapi.HTTPRouteRule{{
 			BackendRefs: backends,
 		}},
 	})

--- a/test/conformance/gateway-api/rule.go
+++ b/test/conformance/gateway-api/rule.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/utils/pointer"
 	"knative.dev/net-gateway-api/test"
 	"knative.dev/networking/pkg/apis/networking"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // TestRule verifies that an Ingress properly dispatches to backends based on different rules.
@@ -37,70 +37,70 @@ func TestRule(t *testing.T) {
 	fooName, fooPort, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
 	barName, barPort, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
 
-	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(fooName + ".example.com"), gatewayv1alpha2.Hostname(barName + ".example.com")},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(fooName + ".example.com"), gatewayapi.Hostname(barName + ".example.com")},
+		Rules: []gatewayapi.HTTPRouteRule{
 			{
-				BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-					BackendRef: gatewayv1alpha2.BackendRef{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+				BackendRefs: []gatewayapi.HTTPBackendRef{{
+					BackendRef: gatewayapi.BackendRef{
+						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Port: portNumPtr(fooPort),
-							Name: gatewayv1alpha2.ObjectName(fooName),
+							Name: gatewayapi.ObjectName(fooName),
 						},
 					},
-					Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-						Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-						RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-							Set: []gatewayv1alpha2.HTTPHeader{{
+					Filters: []gatewayapi.HTTPRouteFilter{{
+						Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+							Set: []gatewayapi.HTTPHeader{{
 								Name:  headerName,
 								Value: fooName,
 							}},
 						}},
 					},
 				}},
-				Matches: []gatewayv1alpha2.HTTPRouteMatch{{
-					Headers: []gatewayv1alpha2.HTTPHeaderMatch{{
-						Type:  headerMatchTypePtr(gatewayv1alpha2.HeaderMatchExact),
+				Matches: []gatewayapi.HTTPRouteMatch{{
+					Headers: []gatewayapi.HTTPHeaderMatch{{
+						Type:  headerMatchTypePtr(gatewayapi.HeaderMatchExact),
 						Name:  "Host",
 						Value: fooName + ".example.com",
 					}},
 					// This should be removed once https://github.com/kubernetes-sigs/gateway-api/issues/563 was solved.
-					Path: &gatewayv1alpha2.HTTPPathMatch{
-						Type:  pathMatchTypePtr(gatewayv1alpha2.PathMatchPathPrefix),
+					Path: &gatewayapi.HTTPPathMatch{
+						Type:  pathMatchTypePtr(gatewayapi.PathMatchPathPrefix),
 						Value: pointer.String("/"),
 					},
 				}},
 			},
 			{
-				BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-					BackendRef: gatewayv1alpha2.BackendRef{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+				BackendRefs: []gatewayapi.HTTPBackendRef{{
+					BackendRef: gatewayapi.BackendRef{
+						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Port: portNumPtr(barPort),
-							Name: gatewayv1alpha2.ObjectName(barName),
+							Name: gatewayapi.ObjectName(barName),
 						},
 					},
-					Filters: []gatewayv1alpha2.HTTPRouteFilter{{
-						Type: gatewayv1alpha2.HTTPRouteFilterRequestHeaderModifier,
-						RequestHeaderModifier: &gatewayv1alpha2.HTTPRequestHeaderFilter{
-							Set: []gatewayv1alpha2.HTTPHeader{{
+					Filters: []gatewayapi.HTTPRouteFilter{{
+						Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayapi.HTTPRequestHeaderFilter{
+							Set: []gatewayapi.HTTPHeader{{
 								Name:  headerName,
 								Value: barName,
 							}},
 						}},
 					},
 				}},
-				Matches: []gatewayv1alpha2.HTTPRouteMatch{{
-					Headers: []gatewayv1alpha2.HTTPHeaderMatch{{
-						Type:  headerMatchTypePtr(gatewayv1alpha2.HeaderMatchExact),
+				Matches: []gatewayapi.HTTPRouteMatch{{
+					Headers: []gatewayapi.HTTPHeaderMatch{{
+						Type:  headerMatchTypePtr(gatewayapi.HeaderMatchExact),
 						Name:  "Host",
 						Value: barName + ".example.com",
 					}},
 					// This should be removed once https://github.com/kubernetes-sigs/gateway-api/issues/563 was solved.
-					Path: &gatewayv1alpha2.HTTPPathMatch{
-						Type:  pathMatchTypePtr(gatewayv1alpha2.PathMatchPathPrefix),
+					Path: &gatewayapi.HTTPPathMatch{
+						Type:  pathMatchTypePtr(gatewayapi.PathMatchPathPrefix),
 						Value: pointer.String("/"),
 					},
 				}},

--- a/test/conformance/gateway-api/timeout.go
+++ b/test/conformance/gateway-api/timeout.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"knative.dev/net-gateway-api/test"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // TestTimeout verifies that an Ingress implements "no timeout".
@@ -35,17 +35,17 @@ func TestTimeout(t *testing.T) {
 	name, port, _ := CreateTimeoutService(ctx, t, clients)
 
 	// Create a simple HTTPRoute over the Service.
-	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(name + ".example.com")},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{{
-			BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-				BackendRef: gatewayv1alpha2.BackendRef{
-					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(name + ".example.com")},
+		Rules: []gatewayapi.HTTPRouteRule{{
+			BackendRefs: []gatewayapi.HTTPBackendRef{{
+				BackendRef: gatewayapi.BackendRef{
+					BackendObjectReference: gatewayapi.BackendObjectReference{
 						Port: portNumPtr(port),
-						Name: gatewayv1alpha2.ObjectName(name),
+						Name: gatewayapi.ObjectName(name),
 					}}},
 			},
 		}},

--- a/test/conformance/gateway-api/util_test.go
+++ b/test/conformance/gateway-api/util_test.go
@@ -20,58 +20,58 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func TestIsHTTPRouteReady(t *testing.T) {
 	tests := []struct {
 		name          string
 		expect        bool
-		gatewayStatus []gatewayv1alpha2.RouteParentStatus
+		gatewayStatus []gatewayapi.RouteParentStatus
 	}{
 		{
 			name: "Zero gateway - it does not have status condition",
 		}, {
 			name:   "One gateway - it has Admitted condition true",
 			expect: true,
-			gatewayStatus: []gatewayv1alpha2.RouteParentStatus{{
-				ParentRef: gatewayv1alpha2.ParentReference{Name: "foo", Namespace: namespacePtr("foo")},
+			gatewayStatus: []gatewayapi.RouteParentStatus{{
+				ParentRef: gatewayapi.ParentReference{Name: "foo", Namespace: namespacePtr("foo")},
 				Conditions: []metav1.Condition{{
-					Type:   string(gatewayv1alpha2.RouteConditionAccepted),
+					Type:   string(gatewayapi.RouteConditionAccepted),
 					Status: metav1.ConditionTrue,
 				}},
 			}},
 		}, {
 			name: "One gateway - it has Admitted condition false",
-			gatewayStatus: []gatewayv1alpha2.RouteParentStatus{{
-				ParentRef: gatewayv1alpha2.ParentReference{Name: "foo", Namespace: namespacePtr("foo")},
+			gatewayStatus: []gatewayapi.RouteParentStatus{{
+				ParentRef: gatewayapi.ParentReference{Name: "foo", Namespace: namespacePtr("foo")},
 				Conditions: []metav1.Condition{{
-					Type:   string(gatewayv1alpha2.RouteConditionAccepted),
+					Type:   string(gatewayapi.RouteConditionAccepted),
 					Status: metav1.ConditionFalse,
 				}},
 			}},
 		}, {
 			name: "One gateway - it does not have Admitted condition",
-			gatewayStatus: []gatewayv1alpha2.RouteParentStatus{{
-				ParentRef: gatewayv1alpha2.ParentReference{Name: "foo", Namespace: namespacePtr("foo")},
+			gatewayStatus: []gatewayapi.RouteParentStatus{{
+				ParentRef: gatewayapi.ParentReference{Name: "foo", Namespace: namespacePtr("foo")},
 			}},
 		}, {
 			name:   "Two gateways - both have Admitted condition true",
 			expect: true,
-			gatewayStatus: []gatewayv1alpha2.RouteParentStatus{
+			gatewayStatus: []gatewayapi.RouteParentStatus{
 				{
-					ParentRef: gatewayv1alpha2.ParentReference{Name: "foo", Namespace: namespacePtr("foo")},
+					ParentRef: gatewayapi.ParentReference{Name: "foo", Namespace: namespacePtr("foo")},
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(gatewayv1alpha2.RouteConditionAccepted),
+							Type:   string(gatewayapi.RouteConditionAccepted),
 							Status: metav1.ConditionTrue,
 						},
 					},
 				}, {
-					ParentRef: gatewayv1alpha2.ParentReference{Name: "bar", Namespace: namespacePtr("bar")},
+					ParentRef: gatewayapi.ParentReference{Name: "bar", Namespace: namespacePtr("bar")},
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(gatewayv1alpha2.RouteConditionAccepted),
+							Type:   string(gatewayapi.RouteConditionAccepted),
 							Status: metav1.ConditionTrue,
 						},
 					},
@@ -79,20 +79,20 @@ func TestIsHTTPRouteReady(t *testing.T) {
 			},
 		}, {
 			name: "Two gateways - one has Admitted condition false",
-			gatewayStatus: []gatewayv1alpha2.RouteParentStatus{
+			gatewayStatus: []gatewayapi.RouteParentStatus{
 				{
-					ParentRef: gatewayv1alpha2.ParentReference{Name: "foo", Namespace: namespacePtr("foo")},
+					ParentRef: gatewayapi.ParentReference{Name: "foo", Namespace: namespacePtr("foo")},
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(gatewayv1alpha2.RouteConditionAccepted),
+							Type:   string(gatewayapi.RouteConditionAccepted),
 							Status: metav1.ConditionFalse,
 						},
 					},
 				}, {
-					ParentRef: gatewayv1alpha2.ParentReference{Name: "bar", Namespace: namespacePtr("bar")},
+					ParentRef: gatewayapi.ParentReference{Name: "bar", Namespace: namespacePtr("bar")},
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(gatewayv1alpha2.RouteConditionAccepted),
+							Type:   string(gatewayapi.RouteConditionAccepted),
 							Status: metav1.ConditionTrue,
 						},
 					},
@@ -100,17 +100,17 @@ func TestIsHTTPRouteReady(t *testing.T) {
 			},
 		}, {
 			name: "Two gateways - one does not have Admitted condition",
-			gatewayStatus: []gatewayv1alpha2.RouteParentStatus{
+			gatewayStatus: []gatewayapi.RouteParentStatus{
 				{
-					ParentRef: gatewayv1alpha2.ParentReference{Name: "foo", Namespace: namespacePtr("foo")},
+					ParentRef: gatewayapi.ParentReference{Name: "foo", Namespace: namespacePtr("foo")},
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(gatewayv1alpha2.RouteConditionAccepted),
+							Type:   string(gatewayapi.RouteConditionAccepted),
 							Status: metav1.ConditionFalse,
 						},
 					},
 				}, {
-					ParentRef: gatewayv1alpha2.ParentReference{Name: "bar", Namespace: namespacePtr("bar")},
+					ParentRef: gatewayapi.ParentReference{Name: "bar", Namespace: namespacePtr("bar")},
 				},
 			},
 		},
@@ -118,9 +118,9 @@ func TestIsHTTPRouteReady(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			httpRoute := &gatewayv1alpha2.HTTPRoute{
-				Status: gatewayv1alpha2.HTTPRouteStatus{
-					RouteStatus: gatewayv1alpha2.RouteStatus{Parents: test.gatewayStatus},
+			httpRoute := &gatewayapi.HTTPRoute{
+				Status: gatewayapi.HTTPRouteStatus{
+					RouteStatus: gatewayapi.RouteStatus{Parents: test.gatewayStatus},
 				},
 			}
 			got, _ := IsHTTPRouteReady(httpRoute)

--- a/test/conformance/gateway-api/websocket.go
+++ b/test/conformance/gateway-api/websocket.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 	"knative.dev/net-gateway-api/test"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // TestWebsocket verifies that websockets may be used via a simple Ingress.
@@ -45,17 +45,17 @@ func TestWebsocket(t *testing.T) {
 	domain := name + ".example.com"
 
 	// Create a simple Ingress over the Service.
-	_, dialCtx, _ := createHTTPRouteReadyDialContext(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, dialCtx, _ := createHTTPRouteReadyDialContext(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(domain)},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{{
-			BackendRefs: []gatewayv1alpha2.HTTPBackendRef{{
-				BackendRef: gatewayv1alpha2.BackendRef{
-					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(domain)},
+		Rules: []gatewayapi.HTTPRouteRule{{
+			BackendRefs: []gatewayapi.HTTPBackendRef{{
+				BackendRef: gatewayapi.BackendRef{
+					BackendObjectReference: gatewayapi.BackendObjectReference{
 						Port: portNumPtr(port),
-						Name: gatewayv1alpha2.ObjectName(name),
+						Name: gatewayapi.ObjectName(name),
 					}}},
 			},
 		}}})
@@ -101,27 +101,27 @@ func TestWebsocketSplit(t *testing.T) {
 	// Create a simple HTTPRoute over the Service.
 	name := test.ObjectNameForTest(t)
 	domain := name + ".example.com"
-	_, dialCtx, _ := createHTTPRouteReadyDialContext(ctx, t, clients, gatewayv1alpha2.HTTPRouteSpec{
-		CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{ParentRefs: []gatewayv1alpha2.ParentReference{
+	_, dialCtx, _ := createHTTPRouteReadyDialContext(ctx, t, clients, gatewayapi.HTTPRouteSpec{
+		CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{
 			testGateway,
 		}},
-		Hostnames: []gatewayv1alpha2.Hostname{gatewayv1alpha2.Hostname(domain)},
-		Rules: []gatewayv1alpha2.HTTPRouteRule{{
-			BackendRefs: []gatewayv1alpha2.HTTPBackendRef{
+		Hostnames: []gatewayapi.Hostname{gatewayapi.Hostname(domain)},
+		Rules: []gatewayapi.HTTPRouteRule{{
+			BackendRefs: []gatewayapi.HTTPBackendRef{
 				{
-					BackendRef: gatewayv1alpha2.BackendRef{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+					BackendRef: gatewayapi.BackendRef{
+						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Port: portNumPtr(bluePort),
-							Name: gatewayv1alpha2.ObjectName(blueName),
+							Name: gatewayapi.ObjectName(blueName),
 						},
 						Weight: pointer.Int32(1),
 					},
 				},
 				{
-					BackendRef: gatewayv1alpha2.BackendRef{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+					BackendRef: gatewayapi.BackendRef{
+						BackendObjectReference: gatewayapi.BackendObjectReference{
 							Port: portNumPtr(greenPort),
-							Name: gatewayv1alpha2.ObjectName(greenName),
+							Name: gatewayapi.ObjectName(greenName),
 						},
 						Weight: pointer.Int32(1),
 					},


### PR DESCRIPTION
- Use ReferenceGrant instead of ReferencePolicy
- When v0.6.0 comes out we can drop v1alpha2.ReferenceGrant

