### PR TITLE
Use v1beta1 Gateway

### DIFF
--- a/third_party/contour/gateway-external.yaml
+++ b/third_party/contour/gateway-external.yaml
@@ -34,14 +34,14 @@ spec:
       type: LoadBalancerService
 ---
 kind: GatewayClass
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: contour-external-gatewayclass
 spec:
   controllerName: projectcontour.io/contour-external/contour
 ---
 kind: Gateway
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: knative-gateway
   namespace: contour-external

--- a/third_party/contour/gateway-internal.yaml
+++ b/third_party/contour/gateway-internal.yaml
@@ -39,14 +39,14 @@ spec:
       type: ClusterIPService
 ---
 kind: GatewayClass
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: contour-internal-gatewayclass
 spec:
   controllerName: projectcontour.io/contour-internal/contour
 ---
 kind: Gateway
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: knative-local-gateway
   namespace: contour-internal

--- a/third_party/istio/300-gateway.yaml
+++ b/third_party/istio/300-gateway.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 kind: Gateway
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: knative-gateway
   namespace: istio-system

--- a/third_party/istio/300-gatewayclass.yaml
+++ b/third_party/istio/300-gatewayclass.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   name: istio


### PR DESCRIPTION
This is a tiny change which bumps v1beta1 Gateway in `third_party` directory.
It started producing the following warning message:

```
$ kubectl apply -f ./third_party/istio
service/knative-local-gateway created
Warning: The v1alpha2 version of Gateway has been deprecated and will be removed in a future release of the API. Please upgrade to v1beta1.
gateway.gateway.networking.k8s.io/knative-local-gateway created
gateway.gateway.networking.k8s.io/knative-gateway created
Warning: The v1alpha2 version of GatewayClass has been deprecated and will be removed in a future release of the API. Please upgrade to v1beta1.
Warning: resource gatewayclasses/istio is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
gatewayclass.gateway.networking.k8s.io/istio configured
```