### PR TITLE
Bump Istio version to 1.7.0

### DIFF
--- a/docs/test-version.md
+++ b/docs/test-version.md
@@ -15,5 +15,5 @@ The following Gateway API version and Ingress were tested as part of the release
 
 | Ingress | Tested version          | Unavailable features           |
 | ------- | ----------------------- | ------------------------------ |
-| Istio   | v1.16.1     | retry,httpoption,host-rewrite   |
+| Istio   | v1.17.0     | retry,httpoption,host-rewrite   |
 | Contour | v1.23.0    | httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,update,host-rewrite |

--- a/hack/test-env.sh
+++ b/hack/test-env.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 export GATEWAY_API_VERSION="v0.6.0"
-export ISTIO_VERSION="1.16.1"
+export ISTIO_VERSION="1.17.0"
 export ISTIO_UNSUPPORTED_E2E_TESTS="retry,httpoption,host-rewrite"
 export CONTOUR_VERSION="v1.23.0"
 export CONTOUR_UNSUPPORTED_E2E_TESTS="httpoption,basics/http2,websocket,websocket/split,grpc,grpc/split,update,host-rewrite"


### PR DESCRIPTION
As per title, this patch bumps Istio version to 1.7.0 for test.