### PR TITLE
Do not bump sigs.k8s.io/gateway-api via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,4 @@ updates:
     ignore:
       - dependency-name: "k8s.io/*"
       - dependency-name: "knative.dev/*"
+      - dependency-name: "sigs.k8s.io/gateway-api"


### PR DESCRIPTION
The automatic PR https://github.com/knative-sandbox/net-gateway-api/pull/503 (bump to 0.7.2) worked fine this time, but we need to bump manual change like https://github.com/knative-sandbox/net-gateway-api/pull/494.
So this patch adds `sigs.k8s.io/gateway-api ` to ignore list.