### PR TITLE
Prune stale HTTPRoutes when tags are removed from Ingress rules

### DIFF
--- a/pkg/reconciler/ingress/fixtures_test.go
+++ b/pkg/reconciler/ingress/fixtures_test.go
@@ -57,6 +57,7 @@ func (r HTTPRoute) Build() *gatewayapi.HTTPRoute {
 				networking.IngressClassAnnotationKey: gatewayAPIIngressClassName,
 			},
 			Labels: map[string]string{
+				networking.IngressLabelKey:    "name",
 				networking.VisibilityLabelKey: "",
 			},
 			OwnerReferences: []metav1.OwnerReference{{

--- a/pkg/reconciler/ingress/resources/httproute.go
+++ b/pkg/reconciler/ingress/resources/httproute.go
@@ -204,6 +204,7 @@ func MakeHTTPRoute(
 			Name:      LongestHost(rule.Hosts),
 			Namespace: ing.Namespace,
 			Labels: kmeta.UnionMaps(ing.Labels, map[string]string{
+				networking.IngressLabelKey:    ing.Name,
 				networking.VisibilityLabelKey: visibility,
 			}),
 			Annotations: kmeta.FilterMap(ing.GetAnnotations(), func(key string) bool {


### PR DESCRIPTION
- Add pruning in reconcileIngress to delete owned HTTPRoutes not referenced
- Add unit test to verify stale route deletion behavior

/kind bug

Fixes #895

Release Note:
```release-note
Fix a bug where HTTPRoutes could remain after tags were removed. Stale routes are now deleted during reconciliation.
```
