### PR TITLE
Add kahirokunn as a net-gateway-api-reviewers in OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,4 +8,4 @@ approvers:
 
 reviewers:
 - serving-reviewers
-- net-gateway-api-approvers
+- net-gateway-api-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -139,6 +139,9 @@ aliases:
   - dprotaso
   net-gateway-api-approvers:
   - dprotaso
+  net-gateway-api-reviewers:
+  - dprotaso
+  - kahirokunn
   net-istio-approvers:
   - skonto
   net-kourier-approvers:


### PR DESCRIPTION
I have been actively using various net-xxx projects in the Knative ecosystem, and I am particularly invested in Envoy Gateway at this time. Through this experience, I have developed a strong interest in advancing the net-gateway-api project and contributing to its progress.
I would be honored to serve as a reviewer for this project and help move it forward. I believe my experience with gateway implementations and my commitment to the Knative community would allow me to provide valuable feedback and support to contributors.
If the maintainers are open to this, I would greatly appreciate the opportunity to contribute as a reviewer.
Thank you for considering this request.
