### PR TITLE
add tag label to HTTPRoute for traffic tag identification

### DIFF
--- a/pkg/reconciler/ingress/resources/helpers.go
+++ b/pkg/reconciler/ingress/resources/helpers.go
@@ -17,8 +17,13 @@ limitations under the License.
 package resources
 
 import (
+	"bytes"
 	"cmp"
 	"slices"
+	"strings"
+	"text/template"
+
+	netcfg "knative.dev/networking/pkg/config"
 )
 
 // LongestHost returns the most specific host.
@@ -36,4 +41,65 @@ import (
 func LongestHost[S ~[]E, E cmp.Ordered](hosts S) E {
 	slices.Sort(hosts)
 	return hosts[len(hosts)-1]
+}
+
+func executeTagTemplate(tmpl *template.Template, name, tag string) string {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, netcfg.TagTemplateValues{Name: name, Tag: tag}); err != nil {
+		return ""
+	}
+	return buf.String()
+}
+
+// TagOfHost extracts the traffic tag name from the first host in hosts
+// by using the tag template. It executes the template with a sentinel
+// value to discover where .Tag appears, then extracts and verifies
+// the tag from the actual hostname.
+// Returns empty string if no tag is found or hosts is empty.
+//
+// Note: templates that reference .Tag more than once are not supported
+// and will always return "". In practice, tag templates use .Tag exactly once.
+func TagOfHost(hosts []string, ingressName string, tmpl *template.Template) string {
+	if len(hosts) == 0 || tmpl == nil {
+		return ""
+	}
+	host := strings.SplitN(hosts[0], ".", 2)[0]
+
+	// No tag if template with empty tag matches
+	if host == executeTagTemplate(tmpl, ingressName, "") {
+		return ""
+	}
+
+	// Execute with a sentinel to discover where .Tag appears in the output.
+	const sentinel = "\x00TAG\x00"
+	result := executeTagTemplate(tmpl, ingressName, sentinel)
+	prefix, suffix, found := strings.Cut(result, sentinel)
+	if !found {
+		return "" // template doesn't use .Tag at all
+	}
+
+	// Check that the host has the expected prefix and suffix.
+	if !strings.HasPrefix(host, prefix) || !strings.HasSuffix(host, suffix) {
+		return ""
+	}
+
+	// Extract the tag by stripping prefix and suffix.
+	tag := host[len(prefix):]
+	if len(suffix) > 0 {
+		if len(tag) < len(suffix) {
+			return ""
+		}
+		tag = tag[:len(tag)-len(suffix)]
+	}
+	if tag == "" {
+		return ""
+	}
+
+	// Forward-verify: re-execute the template with the extracted tag
+	// and confirm it reproduces the host exactly.
+	if executeTagTemplate(tmpl, ingressName, tag) != host {
+		return ""
+	}
+
+	return tag
 }

--- a/pkg/reconciler/ingress/resources/helpers_test.go
+++ b/pkg/reconciler/ingress/resources/helpers_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+	"text/template"
+)
+
+func TestTagOfHost(t *testing.T) {
+	defaultTmpl := "{{.Tag}}-{{.Name}}"
+
+	for _, tc := range []struct {
+		name        string
+		hosts       []string
+		ingressName string
+		tmpl        string
+		want        string
+	}{
+		// --- Existing tests (default template) ---
+		{
+			name:        "no tag",
+			hosts:       []string{"helloworld-go.default.example.com"},
+			ingressName: "helloworld-go",
+			want:        "",
+		}, {
+			name:        "tagged host",
+			hosts:       []string{"auth-helloworld-go.default.example.com"},
+			ingressName: "helloworld-go",
+			want:        "auth",
+		}, {
+			name:        "tag with hyphens",
+			hosts:       []string{"my-tag-helloworld-go.default.example.com"},
+			ingressName: "helloworld-go",
+			want:        "my-tag",
+		}, {
+			name:        "empty hosts",
+			hosts:       []string{},
+			ingressName: "helloworld-go",
+			want:        "",
+		}, {
+			name:        "ingress name with hyphens",
+			hosts:       []string{"v2-my-app.default.example.com"},
+			ingressName: "my-app",
+			want:        "v2",
+		}, {
+			name:        "host without dot",
+			hosts:       []string{"auth-myapp"},
+			ingressName: "myapp",
+			want:        "auth",
+		}, {
+			name:        "no suffix match",
+			hosts:       []string{"other.default.example.com"},
+			ingressName: "helloworld-go",
+			want:        "",
+		}, {
+			name:        "nil hosts",
+			hosts:       nil,
+			ingressName: "helloworld-go",
+			want:        "",
+		}, {
+			name:        "partial ingress name match",
+			hosts:       []string{"test-ingressextra.default.example.com"},
+			ingressName: "ingress",
+			want:        "",
+		},
+
+		// --- Custom template: reversed order {{.Name}}-{{.Tag}} ---
+		{
+			name:        "reversed template: tag extracted",
+			hosts:       []string{"myapp-auth.default.example.com"},
+			ingressName: "myapp",
+			tmpl:        "{{.Name}}-{{.Tag}}",
+			want:        "auth",
+		}, {
+			name:        "reversed template: no tag",
+			hosts:       []string{"myapp.default.example.com"},
+			ingressName: "myapp",
+			tmpl:        "{{.Name}}-{{.Tag}}",
+			want:        "",
+		},
+
+		// --- Custom template: double-dash separator {{.Tag}}--{{.Name}} ---
+		{
+			name:        "double-dash separator: tag extracted",
+			hosts:       []string{"auth--helloworld-go.default.example.com"},
+			ingressName: "helloworld-go",
+			tmpl:        "{{.Tag}}--{{.Name}}",
+			want:        "auth",
+		},
+
+		// --- DomainMapping-like hostnames (default template) ---
+		{
+			name:        "domain mapping: no false tag for custom.example.com",
+			hosts:       []string{"custom.example.com"},
+			ingressName: "custom.example.com",
+			want:        "",
+		}, {
+			name:        "domain mapping: no false tag for foo-bar.example.com",
+			hosts:       []string{"foo-bar.example.com"},
+			ingressName: "foo-bar.example.com",
+			want:        "",
+		},
+
+		// --- Forward verification prevents ambiguous matches (default template) ---
+		{
+			name:        "ambiguous match: ingressName=c resolves tag=a-b",
+			hosts:       []string{"a-b-c.default.example.com"},
+			ingressName: "c",
+			want:        "a-b",
+		}, {
+			name:        "ambiguous match: ingressName=b-c resolves tag=a",
+			hosts:       []string{"a-b-c.default.example.com"},
+			ingressName: "b-c",
+			want:        "a",
+		},
+
+		// --- Template with no separator (edge case): {{.Tag}}{{.Name}} ---
+		{
+			name:        "no separator template: tag extracted",
+			hosts:       []string{"authmyapp.default.example.com"},
+			ingressName: "myapp",
+			tmpl:        "{{.Tag}}{{.Name}}",
+			want:        "auth",
+		},
+
+		// --- Complex template with conditional ---
+		{
+			name:        "conditional template: tag extracted",
+			hosts:       []string{"auth-myapp.default.example.com"},
+			ingressName: "myapp",
+			tmpl:        "{{if .Tag}}{{.Tag}}-{{end}}{{.Name}}",
+			want:        "auth",
+		}, {
+			name:        "conditional template: no tag",
+			hosts:       []string{"myapp.default.example.com"},
+			ingressName: "myapp",
+			tmpl:        "{{if .Tag}}{{.Tag}}-{{end}}{{.Name}}",
+			want:        "",
+		},
+
+		// --- Multi-tag and edge-case templates ---
+		{
+			name:        "multi-tag template: returns empty",
+			hosts:       []string{"auth-myapp-auth.default.example.com"},
+			ingressName: "myapp",
+			tmpl:        "{{.Tag}}-{{.Name}}-{{.Tag}}",
+			want:        "",
+		}, {
+			name:        "tag-only template: extracts tag",
+			hosts:       []string{"auth.default.example.com"},
+			ingressName: "myapp",
+			tmpl:        "{{.Tag}}",
+			want:        "auth",
+		}, {
+			name:        "multi-name template: extracts tag",
+			hosts:       []string{"auth-myapp-myapp.default.example.com"},
+			ingressName: "myapp",
+			tmpl:        "{{.Tag}}-{{.Name}}-{{.Name}}",
+			want:        "auth",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmplSrc := tc.tmpl
+			if tmplSrc == "" {
+				tmplSrc = defaultTmpl
+			}
+			tmpl := template.Must(template.New("tag-template").Parse(tmplSrc))
+			got := TagOfHost(tc.hosts, tc.ingressName, tmpl)
+			if got != tc.want {
+				t.Errorf("TagOfHost(%v, %q, tmpl=%q) = %q, want %q", tc.hosts, tc.ingressName, tc.tmpl, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTagOfHostNilTemplate(t *testing.T) {
+	got := TagOfHost([]string{"auth-myapp.default.example.com"}, "myapp", nil)
+	if got != "" {
+		t.Errorf("TagOfHost with nil template = %q, want empty string", got)
+	}
+}

--- a/pkg/reconciler/ingress/resources/httproute.go
+++ b/pkg/reconciler/ingress/resources/httproute.go
@@ -37,6 +37,12 @@ import (
 	"knative.dev/pkg/kmeta"
 )
 
+const (
+	// TagLabelKey is the label key to indicate which traffic tag
+	// an HTTPRoute is associated with.
+	TagLabelKey = networking.GroupName + "/tag"
+)
+
 func UpdateProbeHash(r *gatewayapi.HTTPRoute, hash string) {
 	// Note: we use indices and references to avoid mutating copies
 	for rIdx := range r.Spec.Rules {
@@ -199,14 +205,20 @@ func MakeHTTPRoute(
 		visibility = "cluster-local"
 	}
 
+	// Build labels for the HTTPRoute
+	labels := map[string]string{
+		networking.IngressLabelKey:    ing.Name,
+		networking.VisibilityLabelKey: visibility,
+	}
+	if tag := TagOfHost(rule.Hosts, ing.Name, config.FromContext(ctx).Network.GetTagTemplate()); tag != "" {
+		labels[TagLabelKey] = tag
+	}
+
 	return &gatewayapi.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      LongestHost(rule.Hosts),
 			Namespace: ing.Namespace,
-			Labels: kmeta.UnionMaps(ing.Labels, map[string]string{
-				networking.IngressLabelKey:    ing.Name,
-				networking.VisibilityLabelKey: visibility,
-			}),
+			Labels:    kmeta.UnionMaps(ing.Labels, labels),
 			Annotations: kmeta.FilterMap(ing.GetAnnotations(), func(key string) bool {
 				return key == corev1.LastAppliedConfigAnnotation
 			}),

--- a/pkg/reconciler/ingress/resources/httproute_test.go
+++ b/pkg/reconciler/ingress/resources/httproute_test.go
@@ -30,6 +30,7 @@ import (
 	"knative.dev/net-gateway-api/pkg/reconciler/ingress/config"
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	networkcfg "knative.dev/networking/pkg/config"
 	"knative.dev/networking/pkg/http/header"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/reconciler"
@@ -546,6 +547,230 @@ func TestMakeHTTPRoute(t *testing.T) {
 							}},
 						},
 					},
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{{
+							Group:     (*gatewayapi.Group)(ptr.To("gateway.networking.k8s.io")),
+							Kind:      (*gatewayapi.Kind)(ptr.To("Gateway")),
+							Namespace: ptr.To[gatewayapi.Namespace]("test-ns"),
+							Name:      gatewayapi.ObjectName("foo"),
+						}},
+					},
+				},
+			}},
+		}, {
+			name: "tagged host adds tag label",
+			ing: &v1alpha1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testIngressName,
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						networking.IngressLabelKey: testIngressName,
+					},
+				},
+				Spec: v1alpha1.IngressSpec{Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{"auth-test-ingress.default.example.com"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "goo",
+									ServicePort: intstr.FromInt(123),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}}},
+			},
+			expected: []*gatewayapi.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "auth-test-ingress.default.example.com",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						networking.IngressLabelKey:          testIngressName,
+						"networking.knative.dev/visibility": "",
+						TagLabelKey:                         "auth",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"auth-test-ingress.default.example.com"},
+					Rules: []gatewayapi.HTTPRouteRule{{
+						BackendRefs: []gatewayapi.HTTPBackendRef{{
+							BackendRef: gatewayapi.BackendRef{
+								BackendObjectReference: gatewayapi.BackendObjectReference{
+									Group: (*gatewayapi.Group)(ptr.To("")),
+									Kind:  (*gatewayapi.Kind)(ptr.To("Service")),
+									Port:  ptr.To[gatewayapi.PortNumber](123),
+									Name:  gatewayapi.ObjectName("goo"),
+								},
+								Weight: ptr.To(int32(100)),
+							},
+							Filters: []gatewayapi.HTTPRouteFilter{{
+								Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+								RequestHeaderModifier: &gatewayapi.HTTPHeaderFilter{
+									Set: []gatewayapi.HTTPHeader{},
+								},
+							}},
+						}},
+						Matches: []gatewayapi.HTTPRouteMatch{{
+							Path: &gatewayapi.HTTPPathMatch{
+								Type:  ptr.To(gatewayapi.PathMatchPathPrefix),
+								Value: ptr.To("/"),
+							},
+						}},
+					}},
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{{
+							Group:     (*gatewayapi.Group)(ptr.To("gateway.networking.k8s.io")),
+							Kind:      (*gatewayapi.Kind)(ptr.To("Gateway")),
+							Namespace: ptr.To[gatewayapi.Namespace]("test-ns"),
+							Name:      gatewayapi.ObjectName("foo"),
+						}},
+					},
+				},
+			}},
+		}, {
+			name: "untagged host does not add tag label",
+			ing: &v1alpha1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testIngressName,
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						networking.IngressLabelKey: testIngressName,
+					},
+				},
+				Spec: v1alpha1.IngressSpec{Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{"test-ingress.default.example.com"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "goo",
+									ServicePort: intstr.FromInt(123),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}}},
+			},
+			expected: []*gatewayapi.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress.default.example.com",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						networking.IngressLabelKey:          testIngressName,
+						"networking.knative.dev/visibility": "",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"test-ingress.default.example.com"},
+					Rules: []gatewayapi.HTTPRouteRule{{
+						BackendRefs: []gatewayapi.HTTPBackendRef{{
+							BackendRef: gatewayapi.BackendRef{
+								BackendObjectReference: gatewayapi.BackendObjectReference{
+									Group: (*gatewayapi.Group)(ptr.To("")),
+									Kind:  (*gatewayapi.Kind)(ptr.To("Service")),
+									Port:  ptr.To[gatewayapi.PortNumber](123),
+									Name:  gatewayapi.ObjectName("goo"),
+								},
+								Weight: ptr.To(int32(100)),
+							},
+							Filters: []gatewayapi.HTTPRouteFilter{{
+								Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+								RequestHeaderModifier: &gatewayapi.HTTPHeaderFilter{
+									Set: []gatewayapi.HTTPHeader{},
+								},
+							}},
+						}},
+						Matches: []gatewayapi.HTTPRouteMatch{{
+							Path: &gatewayapi.HTTPPathMatch{
+								Type:  ptr.To(gatewayapi.PathMatchPathPrefix),
+								Value: ptr.To("/"),
+							},
+						}},
+					}},
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{{
+							Group:     (*gatewayapi.Group)(ptr.To("gateway.networking.k8s.io")),
+							Kind:      (*gatewayapi.Kind)(ptr.To("Gateway")),
+							Namespace: ptr.To[gatewayapi.Namespace]("test-ns"),
+							Name:      gatewayapi.ObjectName("foo"),
+						}},
+					},
+				},
+			}},
+		}, {
+			name: "tagged host with custom template adds tag label",
+			changeConfig: func(c *config.Config) {
+				c.Network.TagTemplate = "{{.Name}}-{{.Tag}}"
+			},
+			ing: &v1alpha1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testIngressName,
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						networking.IngressLabelKey: testIngressName,
+					},
+				},
+				Spec: v1alpha1.IngressSpec{Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{"test-ingress-v2.default.example.com"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "goo",
+									ServicePort: intstr.FromInt(123),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}}},
+			},
+			expected: []*gatewayapi.HTTPRoute{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress-v2.default.example.com",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						networking.IngressLabelKey:          testIngressName,
+						"networking.knative.dev/visibility": "",
+						TagLabelKey:                         "v2",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					Hostnames: []gatewayapi.Hostname{"test-ingress-v2.default.example.com"},
+					Rules: []gatewayapi.HTTPRouteRule{{
+						BackendRefs: []gatewayapi.HTTPBackendRef{{
+							BackendRef: gatewayapi.BackendRef{
+								BackendObjectReference: gatewayapi.BackendObjectReference{
+									Group: (*gatewayapi.Group)(ptr.To("")),
+									Kind:  (*gatewayapi.Kind)(ptr.To("Service")),
+									Port:  ptr.To[gatewayapi.PortNumber](123),
+									Name:  gatewayapi.ObjectName("goo"),
+								},
+								Weight: ptr.To(int32(100)),
+							},
+							Filters: []gatewayapi.HTTPRouteFilter{{
+								Type: gatewayapi.HTTPRouteFilterRequestHeaderModifier,
+								RequestHeaderModifier: &gatewayapi.HTTPHeaderFilter{
+									Set: []gatewayapi.HTTPHeader{},
+								},
+							}},
+						}},
+						Matches: []gatewayapi.HTTPRouteMatch{{
+							Path: &gatewayapi.HTTPPathMatch{
+								Type:  ptr.To(gatewayapi.PathMatchPathPrefix),
+								Value: ptr.To("/"),
+							},
+						}},
+					}},
 					CommonRouteSpec: gatewayapi.CommonRouteSpec{
 						ParentRefs: []gatewayapi.ParentReference{{
 							Group:     (*gatewayapi.Group)(ptr.To("gateway.networking.k8s.io")),
@@ -1231,6 +1456,9 @@ func (t *testConfigStore) ToContext(ctx context.Context) context.Context {
 }
 
 var testConfig = &config.Config{
+	Network: &networkcfg.Config{
+		TagTemplate: networkcfg.DefaultTagTemplate,
+	},
 	GatewayPlugin: &config.GatewayPlugin{
 		ExternalGateways: []config.Gateway{{
 			NamespacedName:    types.NamespacedName{Namespace: "test-ns", Name: "foo"},


### PR DESCRIPTION
# Changes

When a Knative Service has traffic tags, tagged HTTPRoutes are generated but have no metadata indicating which tag they belong to. This makes it difficult for external tools to identify the traffic tag from HTTPRoute resources.

- :gift: Add `networking.internal.knative.dev/tag` label to tagged HTTPRoutes

/kind enhancement

**Release Note**

```release-note
Add `networking.internal.knative.dev/tag` label to HTTPRoutes so that traffic tags are identifiable from HTTPRoute metadata.
```

**Docs**

```docs
N/A
```

## Manual testing

Deployed a Knative Service with a traffic tag and confirmed the `networking.internal.knative.dev/tag` label is present on the tagged HTTPRoute:

<img width="3454" height="1140" alt="CleanShot 2026-03-08 at 22 13 26@2x" src="https://github.com/user-attachments/assets/9c7a5a63-55fa-407d-9017-4c5ff51aca6a" />
