### PR TITLE
add tag-to-host support

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -107,7 +107,7 @@ func (c *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 	routesReady := true
 
 	desiredRouteNames := sets.New[string]()
-	for _, rule := range ing.Spec.Rules {
+	for _, rule := range resources.DesiredHTTPRouteRules(ing) {
 		desiredRouteNames.Insert(resources.LongestHost(rule.Hosts))
 
 		httproute, probeTargets, err := c.reconcileHTTPRoute(ctx, ingressHash, ing, &rule)

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -191,6 +191,32 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Created", "Created HTTPRoute \"example.com\""),
 		},
 	}, {
+		Name: "first reconcile ingress with tag-to-host annotation",
+		Key:  "ns/name",
+		Objects: append([]runtime.Object{
+			ing(withBasicSpec, withGatewayAPIclass, withTagToHostHeaderRoute("blue", "blue.example.com")),
+		}, servicesAndEndpoints...),
+		WantCreates: desiredHTTPRoutes(t, ing(withBasicSpec, withGatewayAPIclass, withTagToHostHeaderRoute("blue", "blue.example.com"))),
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: ing(withBasicSpec, withGatewayAPIclass, withTagToHostHeaderRoute("blue", "blue.example.com"), func(i *v1alpha1.Ingress) {
+				i.Status.InitializeConditions()
+				i.Status.MarkIngressNotReady("HTTPRouteNotReady", "Waiting for HTTPRoute becomes Ready.")
+				i.Status.MarkLoadBalancerNotReady()
+			}),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "ns",
+			},
+			Name:  "name",
+			Patch: []byte(`{"metadata":{"finalizers":["ingresses.networking.internal.knative.dev"],"resourceVersion":""}}`),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", `Updated "name" finalizers`),
+			Eventf(corev1.EventTypeNormal, "Created", "Created HTTPRoute \"example.com\""),
+			Eventf(corev1.EventTypeNormal, "Created", "Created HTTPRoute \"blue.example.com\""),
+		},
+	}, {
 		Name: "reconcile ready ingress",
 		Key:  "ns/name",
 		Objects: append([]runtime.Object{
@@ -2474,6 +2500,23 @@ func httpRoute(t *testing.T, i *v1alpha1.Ingress, opts ...HTTPRouteOption) runti
 	return httpRoute
 }
 
+func desiredHTTPRoutes(t *testing.T, i *v1alpha1.Ingress) []runtime.Object {
+	t.Helper()
+	ingCopy := i.DeepCopy()
+	ingress.InsertProbe(ingCopy)
+	ctx := (&testConfigStore{config: defaultConfig}).ToContext(context.Background())
+	rules := resources.DesiredHTTPRouteRules(ingCopy)
+	objects := make([]runtime.Object, 0, len(rules))
+	for i := range rules {
+		httpRoute, err := resources.MakeHTTPRoute(ctx, ingCopy, &rules[i])
+		if err != nil {
+			t.Fatalf("MakeHTTPRoute failed: %v", err)
+		}
+		objects = append(objects, httpRoute)
+	}
+	return objects
+}
+
 func httpRouteReady(h *gatewayapi.HTTPRoute) {
 	h.Status.Parents = []gatewayapi.RouteParentStatus{{
 		Conditions: []metav1.Condition{{
@@ -2489,6 +2532,21 @@ func withGatewayAPIclass(i *v1alpha1.Ingress) {
 	withAnnotation(map[string]string{
 		networking.IngressClassAnnotationKey: gatewayAPIIngressClassName,
 	})(i)
+}
+
+func withTagToHostHeaderRoute(tag, host string) IngressOption {
+	return func(i *v1alpha1.Ingress) {
+		withAnnotation(map[string]string{
+			networking.TagToHostAnnotationKey: fmt.Sprintf(`{"%s":["%s"]}`, tag, host),
+		})(i)
+
+		tagPath := i.Spec.Rules[0].HTTP.Paths[0].DeepCopy()
+		tagPath.Headers = map[string]v1alpha1.HeaderMatch{
+			header.RouteTagKey: {Exact: tag},
+		}
+		tagPath.AppendHeaders = nil
+		i.Spec.Rules[0].HTTP.Paths = append([]v1alpha1.HTTPIngressPath{*tagPath}, i.Spec.Rules[0].HTTP.Paths...)
+	}
 }
 
 func withStatusManager(f *fakeStatusManager) context.Context {

--- a/pkg/reconciler/ingress/resources/httproute.go
+++ b/pkg/reconciler/ingress/resources/httproute.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/pkg/features"
@@ -34,6 +35,7 @@ import (
 	"knative.dev/networking/pkg/apis/networking"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/networking/pkg/http/header"
+	netingress "knative.dev/networking/pkg/ingress"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -186,6 +188,32 @@ func HTTPRouteKey(ing *netv1alpha1.Ingress, rule *netv1alpha1.IngressRule) types
 		Name:      LongestHost(rule.Hosts),
 		Namespace: ing.Namespace,
 	}
+}
+
+type tagRouteKey struct {
+	tag        string
+	visibility netv1alpha1.IngressVisibility
+}
+
+// DesiredHTTPRouteRules returns the full set of KIngress rules that should be
+// materialized as Gateway API HTTPRoutes. This includes synthetic tag-host rules
+// derived from networking.TagToHostAnnotationKey when the source KIngress only
+// carries header-based tag paths.
+func DesiredHTTPRouteRules(ing *netv1alpha1.Ingress) []netv1alpha1.IngressRule {
+	tagToHosts := netingress.TagToHosts(ing)
+	tagHostCoverage := getTagHostCoverage(ing, tagToHosts)
+
+	rules := make([]netv1alpha1.IngressRule, 0, len(ing.Spec.Rules)+len(tagToHosts))
+	for i := range ing.Spec.Rules {
+		rule := ing.Spec.Rules[i].DeepCopy()
+		if tags := netingress.HostRouteTags(rule); tags.Len() == 1 {
+			tag := sets.List(tags)[0]
+			rule.Hosts = mergeHosts(rule.Hosts, netingress.HostsForTag(tag, rule.Visibility, tagToHosts))
+		}
+		rules = append(rules, *rule)
+		rules = append(rules, syntheticTagHostRules(&ing.Spec.Rules[i], tagToHosts, tagHostCoverage)...)
+	}
+	return rules
 }
 
 // MakeHTTPRoute creates HTTPRoute to set up routing rules.
@@ -366,6 +394,61 @@ func makeHTTPRouteRule(gw config.Gateway, rule *netv1alpha1.IngressRule) []gatew
 		rules = append(rules, rule)
 	}
 	return rules
+}
+
+func syntheticTagHostRules(
+	rule *netv1alpha1.IngressRule,
+	tagToHosts map[string]sets.Set[string],
+	tagHostCoverage map[tagRouteKey]sets.Set[string],
+) []netv1alpha1.IngressRule {
+	tagPaths := make(map[string][]netv1alpha1.HTTPIngressPath)
+	for _, path := range rule.HTTP.Paths {
+		tag := netingress.RouteTagHeaderValue(path.Headers)
+		if tag == "" {
+			continue
+		}
+		tagPaths[tag] = append(tagPaths[tag], *netingress.MakeTagHostIngressPath(&path, tag))
+	}
+
+	rules := make([]netv1alpha1.IngressRule, 0, len(tagPaths))
+	for _, tag := range sets.List(sets.KeySet(tagPaths)) {
+		hosts := netingress.HostsForTag(tag, rule.Visibility, tagToHosts)
+		if coveredHosts, ok := tagHostCoverage[tagRouteKey{tag: tag, visibility: rule.Visibility}]; ok {
+			hosts = hosts.Difference(coveredHosts)
+		}
+		if hosts.Len() == 0 {
+			continue
+		}
+
+		tagRule := rule.DeepCopy()
+		tagRule.Hosts = sets.List(hosts)
+		tagRule.HTTP = &netv1alpha1.HTTPIngressRuleValue{
+			Paths: tagPaths[tag],
+		}
+		rules = append(rules, *tagRule)
+	}
+	return rules
+}
+
+func getTagHostCoverage(ing *netv1alpha1.Ingress, tagToHosts map[string]sets.Set[string]) map[tagRouteKey]sets.Set[string] {
+	coverage := make(map[tagRouteKey]sets.Set[string])
+	for i := range ing.Spec.Rules {
+		rule := &ing.Spec.Rules[i]
+		for tag := range netingress.HostRouteTags(rule) {
+			key := tagRouteKey{tag: tag, visibility: rule.Visibility}
+			if _, ok := coverage[key]; !ok {
+				coverage[key] = sets.New[string]()
+			}
+			coverage[key].Insert(mergeHosts(rule.Hosts, netingress.HostsForTag(tag, rule.Visibility, tagToHosts))...)
+		}
+	}
+	return coverage
+}
+
+func mergeHosts(hosts []string, extraHosts sets.Set[string]) []string {
+	merged := sets.New(hosts...)
+	merged.Insert(sets.List(extraHosts)...)
+	return sets.List(merged)
 }
 
 type HTTPHeaderList []gatewayapi.HTTPHeader

--- a/pkg/reconciler/ingress/resources/httproute_test.go
+++ b/pkg/reconciler/ingress/resources/httproute_test.go
@@ -645,6 +645,162 @@ func TestMakeHTTPRoute(t *testing.T) {
 	}
 }
 
+func TestDesiredHTTPRouteRules_TagToHostAnnotation(t *testing.T) {
+	ing := &v1alpha1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testIngressName,
+			Namespace: testNamespace,
+			Annotations: map[string]string{
+				networking.TagToHostAnnotationKey: `{"blue":["blue.example.com","blue.test-ns.svc.cluster.local"]}`,
+			},
+		},
+		Spec: v1alpha1.IngressSpec{
+			Rules: []v1alpha1.IngressRule{{
+				Hosts:      []string{"example.com"},
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
+				HTTP: &v1alpha1.HTTPIngressRuleValue{
+					Paths: []v1alpha1.HTTPIngressPath{{
+						Headers: map[string]v1alpha1.HeaderMatch{
+							header.RouteTagKey: {Exact: "blue"},
+						},
+						Splits: []v1alpha1.IngressBackendSplit{{
+							IngressBackend: v1alpha1.IngressBackend{
+								ServiceName:      "goo",
+								ServiceNamespace: testNamespace,
+								ServicePort:      intstr.FromInt(80),
+							},
+							Percent: 100,
+						}},
+					}, {
+						Splits: []v1alpha1.IngressBackendSplit{{
+							IngressBackend: v1alpha1.IngressBackend{
+								ServiceName:      "doo",
+								ServiceNamespace: testNamespace,
+								ServicePort:      intstr.FromInt(81),
+							},
+							Percent: 100,
+						}},
+					}},
+				},
+			}, {
+				Hosts:      []string{"example.test-ns", "example.test-ns.svc", "example.test-ns.svc.cluster.local"},
+				Visibility: v1alpha1.IngressVisibilityClusterLocal,
+				HTTP: &v1alpha1.HTTPIngressRuleValue{
+					Paths: []v1alpha1.HTTPIngressPath{{
+						Headers: map[string]v1alpha1.HeaderMatch{
+							header.RouteTagKey: {Exact: "blue"},
+						},
+						Splits: []v1alpha1.IngressBackendSplit{{
+							IngressBackend: v1alpha1.IngressBackend{
+								ServiceName:      "goo",
+								ServiceNamespace: testNamespace,
+								ServicePort:      intstr.FromInt(80),
+							},
+							Percent: 100,
+						}},
+					}},
+				},
+			}},
+		},
+	}
+
+	got := DesiredHTTPRouteRules(ing)
+	if gotLen, wantLen := len(got), 4; gotLen != wantLen {
+		t.Fatalf("Expected %d rules, got %d", wantLen, gotLen)
+	}
+
+	rulesByName := make(map[string]v1alpha1.IngressRule, len(got))
+	for _, rule := range got {
+		rulesByName[LongestHost(rule.Hosts)] = rule
+	}
+
+	externalRule, ok := rulesByName["blue.example.com"]
+	if !ok {
+		t.Fatalf("Expected synthetic external tag rule, got %v", sets.List(sets.KeySet(rulesByName)))
+	}
+	if diff := cmp.Diff([]string{"blue.example.com"}, externalRule.Hosts); diff != "" {
+		t.Fatalf("Unexpected synthetic external hosts (-want +got):\n%s", diff)
+	}
+	if gotTag := externalRule.HTTP.Paths[0].AppendHeaders[header.RouteTagKey]; gotTag != "blue" {
+		t.Fatalf("Expected synthetic external route to append tag header, got %q", gotTag)
+	}
+	if _, ok := externalRule.HTTP.Paths[0].Headers[header.RouteTagKey]; ok {
+		t.Fatal("Expected synthetic external route to drop the tag header match")
+	}
+
+	clusterLocalRule, ok := rulesByName["blue.test-ns.svc.cluster.local"]
+	if !ok {
+		t.Fatalf("Expected synthetic cluster-local tag rule, got %v", sets.List(sets.KeySet(rulesByName)))
+	}
+	expectedLocalHosts := []string{
+		"blue.test-ns",
+		"blue.test-ns.svc",
+		"blue.test-ns.svc.cluster.local",
+	}
+	if diff := cmp.Diff(expectedLocalHosts, clusterLocalRule.Hosts); diff != "" {
+		t.Fatalf("Unexpected synthetic cluster-local hosts (-want +got):\n%s", diff)
+	}
+	if gotTag := clusterLocalRule.HTTP.Paths[0].AppendHeaders[header.RouteTagKey]; gotTag != "blue" {
+		t.Fatalf("Expected synthetic cluster-local route to append tag header, got %q", gotTag)
+	}
+}
+
+func TestDesiredHTTPRouteRules_TagToHostAnnotationDoesNotDuplicateHostRules(t *testing.T) {
+	ing := &v1alpha1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testIngressName,
+			Namespace: testNamespace,
+			Annotations: map[string]string{
+				networking.TagToHostAnnotationKey: `{"blue":["blue.example.com"]}`,
+			},
+		},
+		Spec: v1alpha1.IngressSpec{
+			Rules: []v1alpha1.IngressRule{{
+				Hosts:      []string{"example.com"},
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
+				HTTP: &v1alpha1.HTTPIngressRuleValue{
+					Paths: []v1alpha1.HTTPIngressPath{{
+						Headers: map[string]v1alpha1.HeaderMatch{
+							header.RouteTagKey: {Exact: "blue"},
+						},
+						Splits: []v1alpha1.IngressBackendSplit{{
+							IngressBackend: v1alpha1.IngressBackend{
+								ServiceName:      "goo",
+								ServiceNamespace: testNamespace,
+								ServicePort:      intstr.FromInt(80),
+							},
+							Percent: 100,
+						}},
+					}},
+				},
+			}, {
+				Hosts:      []string{"blue.example.com"},
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
+				HTTP: &v1alpha1.HTTPIngressRuleValue{
+					Paths: []v1alpha1.HTTPIngressPath{{
+						AppendHeaders: map[string]string{
+							header.RouteTagKey: "blue",
+						},
+						Splits: []v1alpha1.IngressBackendSplit{{
+							IngressBackend: v1alpha1.IngressBackend{
+								ServiceName:      "goo",
+								ServiceNamespace: testNamespace,
+								ServicePort:      intstr.FromInt(80),
+							},
+							Percent: 100,
+						}},
+					}},
+				},
+			}},
+		},
+	}
+
+	got := DesiredHTTPRouteRules(ing)
+	if gotLen, wantLen := len(got), 2; gotLen != wantLen {
+		t.Fatalf("Expected %d rules, got %d", wantLen, gotLen)
+	}
+}
+
 func TestAddEndpointProbes(t *testing.T) {
 	tcs := &testConfigStore{config: testConfig}
 	ctx := tcs.ToContext(context.Background())

--- a/vendor/knative.dev/networking/pkg/apis/networking/register.go
+++ b/vendor/knative.dev/networking/pkg/apis/networking/register.go
@@ -42,8 +42,12 @@ const (
 	RolloutAnnotationKey = GroupName + "/rollout"
 
 	// TagToHostAnnotationKey is the annotation key used for storing a JSON map of
-	// tags to host names
+	// tag names to hostnames that should be routed to that tag.
 	TagToHostAnnotationKey = GroupName + "/tag-to-host"
+
+	// TagLabelKey is the label key attached to per-tag Ingress resources
+	// to indicate which traffic tag the Ingress corresponds to.
+	TagLabelKey = GroupName + "/tag"
 )
 
 const (

--- a/vendor/knative.dev/networking/pkg/ingress/tags.go
+++ b/vendor/knative.dev/networking/pkg/ingress/tags.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"encoding/json"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	apisnet "knative.dev/networking/pkg/apis/networking"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/networking/pkg/http/header"
+	"knative.dev/pkg/network"
+)
+
+// TagToHosts parses the tag-to-host annotation into sets keyed by tag.
+// Invalid annotations and empty host lists are ignored.
+func TagToHosts(ing *v1alpha1.Ingress) map[string]sets.Set[string] {
+	serialized := ing.GetAnnotations()[apisnet.TagToHostAnnotationKey]
+	if serialized == "" {
+		return nil
+	}
+
+	parsed := make(map[string][]string)
+	if err := json.Unmarshal([]byte(serialized), &parsed); err != nil {
+		return nil
+	}
+
+	tagToHosts := make(map[string]sets.Set[string], len(parsed))
+	for tag, hosts := range parsed {
+		if len(hosts) == 0 {
+			continue
+		}
+		tagToHosts[tag] = sets.New(hosts...)
+	}
+	return tagToHosts
+}
+
+// HostsForTag returns the hostnames for a tag filtered by ingress visibility.
+func HostsForTag(tag string, visibility v1alpha1.IngressVisibility, tagToHosts map[string]sets.Set[string]) sets.Set[string] {
+	if len(tagToHosts) == 0 {
+		return sets.New[string]()
+	}
+	hosts, ok := tagToHosts[tag]
+	if !ok {
+		return sets.New[string]()
+	}
+
+	switch visibility {
+	case v1alpha1.IngressVisibilityClusterLocal:
+		return ExpandedHosts(filterLocalHostnames(hosts))
+	default:
+		return ExpandedHosts(filterNonLocalHostnames(hosts))
+	}
+}
+
+// MakeTagHostIngressPath clones a header-based tag path into a host-based one.
+func MakeTagHostIngressPath(path *v1alpha1.HTTPIngressPath, tag string) *v1alpha1.HTTPIngressPath {
+	tagPath := path.DeepCopy()
+	if tagPath.Headers != nil {
+		delete(tagPath.Headers, header.RouteTagKey)
+		if len(tagPath.Headers) == 0 {
+			tagPath.Headers = nil
+		}
+	}
+	if tagPath.AppendHeaders == nil {
+		tagPath.AppendHeaders = make(map[string]string, 1)
+	}
+	tagPath.AppendHeaders[header.RouteTagKey] = tag
+	return tagPath
+}
+
+// RouteTagHeaderValue returns the value of the route tag header match.
+func RouteTagHeaderValue(headers map[string]v1alpha1.HeaderMatch) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	match, ok := headers[header.RouteTagKey]
+	if !ok {
+		return ""
+	}
+	return match.Exact
+}
+
+// RouteTagAppendValue returns the value of the route tag append header.
+func RouteTagAppendValue(headers map[string]string) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	return headers[header.RouteTagKey]
+}
+
+// RouteHosts returns the hostnames addressed by a path, including synthesized
+// tag hosts for append-header-only tag routes.
+func RouteHosts(ruleHosts sets.Set[string], path *v1alpha1.HTTPIngressPath, visibility v1alpha1.IngressVisibility, tagToHosts map[string]sets.Set[string]) sets.Set[string] {
+	hosts := ruleHosts
+	if tag := RouteTagAppendValue(path.AppendHeaders); tag != "" && RouteTagHeaderValue(path.Headers) == "" {
+		hosts = hosts.Union(HostsForTag(tag, visibility, tagToHosts))
+	}
+	return hosts
+}
+
+// HostRouteTags returns the set of tags already represented as host-based paths.
+func HostRouteTags(rule *v1alpha1.IngressRule) sets.Set[string] {
+	tags := sets.New[string]()
+	if rule.HTTP == nil {
+		return tags
+	}
+	for _, path := range rule.HTTP.Paths {
+		tag := RouteTagAppendValue(path.AppendHeaders)
+		if tag == "" || RouteTagHeaderValue(path.Headers) != "" {
+			continue
+		}
+		tags.Insert(tag)
+	}
+	return tags
+}
+
+func filterLocalHostnames(hosts sets.Set[string]) sets.Set[string] {
+	localSvcSuffix := ".svc." + network.GetClusterDomainName()
+	retained := sets.New[string]()
+	for _, host := range sets.List(hosts) {
+		if strings.HasSuffix(host, localSvcSuffix) {
+			retained.Insert(host)
+		}
+	}
+	return retained
+}
+
+func filterNonLocalHostnames(hosts sets.Set[string]) sets.Set[string] {
+	localSvcSuffix := ".svc." + network.GetClusterDomainName()
+	retained := sets.New[string]()
+	for _, host := range sets.List(hosts) {
+		if !strings.HasSuffix(host, localSvcSuffix) {
+			retained.Insert(host)
+		}
+	}
+	return retained
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
