### PR TITLE
Modernize GoDoc badge to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Knative net-gateway-api
 **[This component is Beta](https://github.com/knative/community/tree/main/mechanics/MATURITY-LEVELS.md)**
 
-[![GoDoc](https://godoc.org/knative-sandbox.dev/net-gateway-api?status.svg)](https://godoc.org/knative.dev/net-gateway-api)
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/knative.dev/net-gateway-api)
 [![Go Report Card](https://goreportcard.com/badge/knative-sandbox/net-gateway-api)](https://goreportcard.com/report/knative-sandbox/net-gateway-api)
 
 net-gateway-api repository contains a KIngress implementation and testing for Knative integration with the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/).


### PR DESCRIPTION
## What

Replace the legacy `godoc.org` badge with the modern `pkg.go.dev` badge style. `godoc.org` has been deprecated and redirects to `pkg.go.dev`.

## Changes

- **README.md**: Replace `godoc.org` badge/link with `pkg.go.dev` badge matching the style used by [`knative/serving`](https://github.com/knative/serving)

## Before / After

| Before | After |
|---|---|
| `godoc.org` SVG (via redirect) | `img.shields.io` badge → `pkg.go.dev` |

/kind cleanup